### PR TITLE
Prefer P256 for client and server certs.

### DIFF
--- a/fleetspeak/src/client/internal/config/manager.go
+++ b/fleetspeak/src/client/internal/config/manager.go
@@ -149,7 +149,7 @@ func StartManager(cfg *config.Configuration, configChanges chan<- *fspb.ClientIn
 }
 
 func (m *Manager) rekey() error {
-	k, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return fmt.Errorf("unable to generate new key: %v", err)
 	}

--- a/fleetspeak/src/comtesting/server_cert.go
+++ b/fleetspeak/src/comtesting/server_cert.go
@@ -33,7 +33,7 @@ import (
 // encoded private key, appropriate for use when creating Fleetspeak test server
 // in a unit test.
 func ServerCert() (cert []byte, key []byte, err error) {
-	privKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to generate key: %v", err)
 	}

--- a/fleetspeak/src/demo/certgen/certgen.go
+++ b/fleetspeak/src/demo/certgen/certgen.go
@@ -47,6 +47,7 @@ import (
 	"time"
 
 	"flag"
+
 	log "github.com/golang/glog"
 )
 
@@ -186,7 +187,7 @@ func createServerCert() {
 
 	caCert, caKey := loadCA()
 
-	privKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		log.Exitf("Unable to generate new CA key: %v", err)
 	}

--- a/fleetspeak/src/demo/configurator/configurator.go
+++ b/fleetspeak/src/demo/configurator/configurator.go
@@ -81,6 +81,7 @@ import (
 	"time"
 
 	"flag"
+
 	log "github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 
@@ -144,7 +145,7 @@ func createServerCert() bool {
 
 	log.Infof("Creating server cert file: %v", f)
 
-	privKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		log.Exitf("Unable to generate new server key: %v", err)
 	}


### PR DESCRIPTION
P256 has a much more optimized, constant time implementation. Sticking with P521 for the example CA cert gen code, though that is probably also debatable.