### PR TITLE
Playing Solomon with the linter.

### DIFF
--- a/fleetspeak/src/client/https/https.go
+++ b/fleetspeak/src/client/https/https.go
@@ -64,7 +64,6 @@ type Communicator struct {
 	DialContext func(ctx context.Context, network, addr string) (net.Conn, error) // If set, will be used to initiate network connections to the server.
 }
 
-// Setup implements client.Communicator.
 func (c *Communicator) Setup(cl comms.Context) error {
 	c.cctx = cl
 	return c.configure()
@@ -152,14 +151,12 @@ func (c *Communicator) configure() error {
 	return nil
 }
 
-// Start implements comms.Communicator.
 func (c *Communicator) Start() error {
 	c.working.Add(1)
 	go c.processingLoop()
 	return nil
 }
 
-// Stop implements comms.Communicator.
 func (c *Communicator) Stop() {
 	c.done()
 	c.working.Wait()
@@ -377,7 +374,6 @@ func (c *Communicator) poll(toSend []comms.MessageInfo) (bool, error) {
 	return false, errors.New("unable to contact any server")
 }
 
-// GetFileIfModified implements comms.Communicator.
 func (c *Communicator) GetFileIfModified(ctx context.Context, service, name string, modSince time.Time) (io.ReadCloser, time.Time, error) {
 	var lastErr error
 	c.hostLock.RLock()

--- a/fleetspeak/src/client/internal/config/manager.go
+++ b/fleetspeak/src/client/internal/config/manager.go
@@ -148,6 +148,7 @@ func StartManager(cfg *config.Configuration, configChanges chan<- *fspb.ClientIn
 	return &r, nil
 }
 
+// Rekey creates a new private key and identity for the client.
 func (m *Manager) Rekey() error {
 	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {

--- a/fleetspeak/src/client/services.go
+++ b/fleetspeak/src/client/services.go
@@ -46,7 +46,7 @@ func (c *serviceConfiguration) ProcessMessage(ctx context.Context, m *fspb.Messa
 	c.lock.RUnlock()
 
 	if target == nil {
-		return fmt.Errorf("Destination service not installed.")
+		return fmt.Errorf("destination service not installed")
 	}
 	select {
 	case target.inbox <- m:

--- a/fleetspeak/src/client/socketservice/socketservice.go
+++ b/fleetspeak/src/client/socketservice/socketservice.go
@@ -87,14 +87,12 @@ func (s *Service) Start(sc service.Context) error {
 	return nil
 }
 
-// Stop implements service.Service.
 func (s *Service) Stop() error {
 	close(s.stop)
 	s.routines.Wait()
 	return nil
 }
 
-// ProcessMessage implements service.Service.
 func (s *Service) ProcessMessage(ctx context.Context, m *fspb.Message) error {
 	select {
 	case s.msgs <- m:

--- a/fleetspeak/src/client/stdinservice/stdinservice.go
+++ b/fleetspeak/src/client/stdinservice/stdinservice.go
@@ -54,21 +54,21 @@ func Factory(conf *fspb.ClientServiceConfig) (service.Service, error) {
 	}, nil
 }
 
-// StdinService implements Service.
+// StdinService implements a service.Service which runs a command one for each
+// message received, passing data to it through stdin and getting the results
+// through stdout/stderr.
 type StdinService struct {
 	conf   *fspb.ClientServiceConfig
 	ssConf *sspb.Config
 	sc     service.Context
 }
 
-// Start implements Service.
 func (s *StdinService) Start(sc service.Context) error {
 	s.sc = sc
 
 	return nil
 }
 
-// ProcessMessage implements Service.
 func (s *StdinService) ProcessMessage(ctx context.Context, m *fspb.Message) error {
 	om := &sspb.OutputMessage{}
 
@@ -155,7 +155,6 @@ func (s *StdinService) ProcessMessage(ctx context.Context, m *fspb.Message) erro
 	return nil
 }
 
-// Stop implements Service.
 func (s *StdinService) Stop() error {
 	return nil
 }

--- a/fleetspeak/src/client/system_service.go
+++ b/fleetspeak/src/client/system_service.go
@@ -52,7 +52,6 @@ type systemService struct {
 	wait          sync.WaitGroup
 }
 
-// Start implements Service.
 func (s *systemService) Start(sc service.Context) error {
 	s.sc = sc
 	s.done = make(chan struct{})
@@ -76,7 +75,6 @@ func (s *systemService) Start(sc service.Context) error {
 	return nil
 }
 
-// ProcessMessage implements Service.
 func (s *systemService) ProcessMessage(_ context.Context, m *fspb.Message) error {
 	if m.MessageType == "RekeyRequest" {
 		if err := s.client.config.Rekey(); err != nil {
@@ -89,7 +87,6 @@ func (s *systemService) ProcessMessage(_ context.Context, m *fspb.Message) error
 	return fmt.Errorf("unable to process message of type: %v", m.MessageType)
 }
 
-// Stop implements Service.
 func (s *systemService) Stop() error {
 	close(s.done)
 	s.wait.Wait()

--- a/fleetspeak/src/demo/messagesaver/messagesaver.go
+++ b/fleetspeak/src/demo/messagesaver/messagesaver.go
@@ -51,10 +51,7 @@ type serv struct {
 
 func (s *serv) Start(sctx service.Context) error {
 	s.sctx = sctx
-	if err := os.MkdirAll(s.path, 0700); err != nil {
-		return err
-	}
-	return nil
+	return os.MkdirAll(s.path, 0700)
 }
 
 func (s *serv) ProcessMessage(ctx context.Context, m *fspb.Message) error {
@@ -80,10 +77,7 @@ func (s *serv) ProcessMessage(ctx context.Context, m *fspb.Message) error {
 		return err
 	}
 	fileName := path.Join(clientDir, t.Format("2006.01.02_15:04:05.000_")+mid.String())
-	if err := ioutil.WriteFile(fileName, []byte(proto.MarshalTextString(m)), 0700); err != nil {
-		return err
-	}
-	return nil
+	return ioutil.WriteFile(fileName, []byte(proto.MarshalTextString(m)), 0700)
 }
 
 func (s *serv) Stop() error {

--- a/fleetspeak/src/server/admin/admin.go
+++ b/fleetspeak/src/server/admin/admin.go
@@ -36,6 +36,7 @@ func NewServer(s db.Store) sgrpc.AdminServer {
 	return adminServer{s}
 }
 
+// adminServer implements admin_grpc.AdminServer.
 type adminServer struct {
 	store db.Store
 }
@@ -119,7 +120,6 @@ func (s adminServer) ListClientContacts(ctx context.Context, req *spb.ListClient
 	}, nil
 }
 
-// InsertMessage implements sgrpc.AdminServer.
 func (s adminServer) InsertMessage(ctx context.Context, m *fspb.Message) (*fspb.EmptyMessage, error) {
 	// At this point, we mostly trust the message we get, but do some basic
 	// sanity checks and generate missing metadata.
@@ -145,7 +145,6 @@ func (s adminServer) InsertMessage(ctx context.Context, m *fspb.Message) (*fspb.
 	return &fspb.EmptyMessage{}, nil
 }
 
-// StoreFile implements sgrpc.AdminServer.
 func (s adminServer) StoreFile(ctx context.Context, req *spb.StoreFileRequest) (*fspb.EmptyMessage, error) {
 	if req.ServiceName == "" || req.FileName == "" {
 		return nil, errors.New("file must have service_name and file_name")
@@ -156,12 +155,10 @@ func (s adminServer) StoreFile(ctx context.Context, req *spb.StoreFileRequest) (
 	return &fspb.EmptyMessage{}, nil
 }
 
-// KeepAlive implements sgrpc.AdminServer.
 func (s adminServer) KeepAlive(ctx context.Context, _ *fspb.EmptyMessage) (*fspb.EmptyMessage, error) {
 	return &fspb.EmptyMessage{}, nil
 }
 
-// BlacklistClient implements sgrpc.BlacklistClient.
 func (s adminServer) BlacklistClient(ctx context.Context, req *spb.BlacklistClientRequest) (*fspb.EmptyMessage, error) {
 	id, err := common.BytesToClientID(req.ClientId)
 	if err != nil {

--- a/fleetspeak/src/server/grpcservice/service.go
+++ b/fleetspeak/src/server/grpcservice/service.go
@@ -60,13 +60,11 @@ func NewGRPCService(c *grpc.ClientConn) *GRPCService {
 	return ret
 }
 
-// Start implements service.Service.
 func (s *GRPCService) Start(sctx service.Context) error {
 	s.sctx = sctx
 	return nil
 }
 
-// Stop implements service.Service.
 func (s *GRPCService) Stop() error {
 	s.l.Lock()
 	defer s.l.Unlock()
@@ -98,7 +96,6 @@ func (s *GRPCService) Update(c *grpc.ClientConn) {
 	}
 }
 
-// ProcessMessage implements service.Service.
 func (s *GRPCService) ProcessMessage(ctx context.Context, m *fspb.Message) error {
 	var err error
 	d := time.Second

--- a/fleetspeak/src/server/https/https.go
+++ b/fleetspeak/src/server/https/https.go
@@ -141,7 +141,6 @@ func (c *Communicator) serve(l net.Listener) {
 	log.Errorf("Serving finished with error: %v", err)
 }
 
-// Setup implements server.Communicator.
 func (c *Communicator) Setup(fs comms.Context) error {
 	c.fs = fs
 	c.l = guardedListener{
@@ -151,7 +150,6 @@ func (c *Communicator) Setup(fs comms.Context) error {
 	return nil
 }
 
-// Start implements server.Communicator.
 func (c *Communicator) Start() error {
 	go c.serve(tls.NewListener(c.l, c.hs.TLSConfig))
 
@@ -161,7 +159,6 @@ func (c *Communicator) Start() error {
 	return nil
 }
 
-// Stop implements server.Communicator.
 func (c *Communicator) Stop() {
 	// The most graceful way to shut down an http.Server is to close the associated listener.
 	c.l.Close()

--- a/fleetspeak/src/server/mysql/broadcaststore.go
+++ b/fleetspeak/src/server/mysql/broadcaststore.go
@@ -99,7 +99,6 @@ func toBroadcastProto(b *dbBroadcast) (*spb.Broadcast, error) {
 	return ret, nil
 }
 
-// CreateBroadcast implements db.BroadcastStore.
 func (d *Datastore) CreateBroadcast(ctx context.Context, b *spb.Broadcast, limit uint64) error {
 	dbB, err := fromBroadcastProto(b)
 	if err != nil {
@@ -140,7 +139,6 @@ func (d *Datastore) CreateBroadcast(ctx context.Context, b *spb.Broadcast, limit
 	})
 }
 
-// SetBroadcastLimit implements db.BroadcastStore.
 func (d *Datastore) SetBroadcastLimit(ctx context.Context, id ids.BroadcastID, limit uint64) error {
 	return d.runInTx(ctx, false, func(tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, "UPDATE broadcasts(message_limit) VALUES(?) WHERE broadcast_id=?", limit, id.String())
@@ -148,7 +146,6 @@ func (d *Datastore) SetBroadcastLimit(ctx context.Context, id ids.BroadcastID, l
 	})
 }
 
-// SaveBroadcastMessage implements db.BroadcastStore.
 func (d *Datastore) SaveBroadcastMessage(ctx context.Context, msg *fspb.Message, bID ids.BroadcastID, cID common.ClientID, aID ids.AllocationID) error {
 	dbm, err := fromMessageProto(msg)
 	if err != nil {
@@ -185,7 +182,6 @@ func (d *Datastore) SaveBroadcastMessage(ctx context.Context, msg *fspb.Message,
 	})
 }
 
-// ListActiveBroadcasts implements db.BroadcastStore.
 func (d *Datastore) ListActiveBroadcasts(ctx context.Context) ([]*db.BroadcastInfo, error) {
 	var ret []*db.BroadcastInfo
 	err := d.runInTx(ctx, true, func(tx *sql.Tx) error {
@@ -271,7 +267,6 @@ func (d *Datastore) ListActiveBroadcasts(ctx context.Context) ([]*db.BroadcastIn
 	return ret, err
 }
 
-// ListSentBroadcasts implements db.BroadcastStore.
 func (d *Datastore) ListSentBroadcasts(ctx context.Context, id common.ClientID) ([]ids.BroadcastID, error) {
 	rs, err := d.db.QueryContext(ctx, "SELECT broadcast_id FROM broadcast_sent WHERE client_id = ?", id.String())
 	if err != nil {
@@ -297,7 +292,6 @@ func (d *Datastore) ListSentBroadcasts(ctx context.Context, id common.ClientID) 
 	return res, nil
 }
 
-// CreateAllocation implements db.BroadcastStore.
 func (d *Datastore) CreateAllocation(ctx context.Context, id ids.BroadcastID, frac float32, expiry time.Time) (*db.AllocationInfo, error) {
 	var ret *db.AllocationInfo
 	err := d.runInTx(ctx, false, func(tx *sql.Tx) error {
@@ -345,7 +339,6 @@ func (d *Datastore) CreateAllocation(ctx context.Context, id ids.BroadcastID, fr
 	return ret, err
 }
 
-// CleanupAllocation implements db.BroadcastStore.
 func (d *Datastore) CleanupAllocation(ctx context.Context, bID ids.BroadcastID, aID ids.AllocationID) error {
 	return d.runInTx(ctx, false, func(tx *sql.Tx) error {
 		var b dbBroadcast

--- a/fleetspeak/src/server/mysql/clientstore.go
+++ b/fleetspeak/src/server/mysql/clientstore.go
@@ -37,7 +37,6 @@ const (
 	bytesToMIB = 1.0 / float64(1<<20)
 )
 
-// ListClients implements db.ClientStore.
 func (d *Datastore) ListClients(ctx context.Context, ids []common.ClientID) ([]*spb.Client, error) {
 	// Return value map, maps string client ids to the return values.
 	retm := make(map[string]*spb.Client)
@@ -121,7 +120,6 @@ func (d *Datastore) ListClients(ctx context.Context, ids []common.ClientID) ([]*
 	return ret, err
 }
 
-// GetClientData implements db.ClientStore.
 func (d *Datastore) GetClientData(ctx context.Context, id common.ClientID) (*db.ClientData, error) {
 	var cd *db.ClientData
 	err := d.runInTx(ctx, true, func(tx *sql.Tx) error {
@@ -157,7 +155,6 @@ func (d *Datastore) GetClientData(ctx context.Context, id common.ClientID) (*db.
 	return cd, err
 }
 
-// AddClient implements db.ClientStore.
 func (d *Datastore) AddClient(ctx context.Context, id common.ClientID, data *db.ClientData) error {
 	return d.runInTx(ctx, false, func(tx *sql.Tx) error {
 		sid := id.String()
@@ -173,25 +170,21 @@ func (d *Datastore) AddClient(ctx context.Context, id common.ClientID, data *db.
 	})
 }
 
-// AddClientLabel implements db.ClientStore.
 func (d *Datastore) AddClientLabel(ctx context.Context, id common.ClientID, l *fspb.Label) error {
 	_, err := d.db.ExecContext(ctx, "INSERT INTO client_labels(client_id, service_name, label) VALUES(?, ?, ?)", id.String(), l.ServiceName, l.Label)
 	return err
 }
 
-// RemoveClientLabel implements db.ClientStore.
 func (d *Datastore) RemoveClientLabel(ctx context.Context, id common.ClientID, l *fspb.Label) error {
 	_, err := d.db.ExecContext(ctx, "DELETE FROM client_labels WHERE client_id=? AND service_name=? AND label=?", id.String(), l.ServiceName, l.Label)
 	return err
 }
 
-// BlacklistClient implements db.ClientStore
 func (d *Datastore) BlacklistClient(ctx context.Context, id common.ClientID) error {
 	_, err := d.db.ExecContext(ctx, "UPDATE clients SET blacklisted=TRUE WHERE client_id=?", id.String())
 	return err
 }
 
-// RecordClientContact implements db.ClientStore.
 func (d *Datastore) RecordClientContact(ctx context.Context, cid common.ClientID, nonceSent, nonceReceived uint64, addr string) (db.ContactID, error) {
 	var res db.ContactID
 	err := d.runInTx(ctx, false, func(tx *sql.Tx) error {
@@ -253,7 +246,6 @@ func (d *Datastore) ListClientContacts(ctx context.Context, id common.ClientID) 
 	return res, nil
 }
 
-// LinkMessagesToContact implements db.ClientStore.
 func (d *Datastore) LinkMessagesToContact(ctx context.Context, contact db.ContactID, ids []common.MessageID) error {
 	c, err := strconv.ParseUint(string(contact), 16, 64)
 	if err != nil {
@@ -271,7 +263,6 @@ func (d *Datastore) LinkMessagesToContact(ctx context.Context, contact db.Contac
 	})
 }
 
-// RecordResourceUsageData implements db.ClientStore.
 func (d *Datastore) RecordResourceUsageData(ctx context.Context, id common.ClientID, rud mpb.ResourceUsageData) error {
 	processStartTime, err := ptypes.Timestamp(rud.ProcessStartTime)
 	if err != nil {
@@ -301,7 +292,6 @@ func (d *Datastore) RecordResourceUsageData(ctx context.Context, id common.Clien
 	})
 }
 
-// FetchResourceUsageRecords implements db.ClientStore.
 func (d *Datastore) FetchResourceUsageRecords(ctx context.Context, id common.ClientID, limit int) ([]*spb.ClientResourceUsageRecord, error) {
 	var records []*spb.ClientResourceUsageRecord
 	err := d.runInTx(ctx, true, func(tx *sql.Tx) error {

--- a/fleetspeak/src/server/mysql/filestore.go
+++ b/fleetspeak/src/server/mysql/filestore.go
@@ -25,7 +25,6 @@ import (
 	"github.com/google/fleetspeak/fleetspeak/src/server/db"
 )
 
-// StoreFile implements db.FileStore.
 func (d *Datastore) StoreFile(ctx context.Context, service, name string, data io.Reader) error {
 	b, err := ioutil.ReadAll(data)
 	if err != nil {
@@ -38,7 +37,6 @@ func (d *Datastore) StoreFile(ctx context.Context, service, name string, data io
 	})
 }
 
-// StatFile implements db.FileStore.
 func (d *Datastore) StatFile(ctx context.Context, service, name string) (time.Time, error) {
 	var ts int64
 
@@ -50,7 +48,6 @@ func (d *Datastore) StatFile(ctx context.Context, service, name string) (time.Ti
 	return time.Unix(0, ts).UTC(), err
 }
 
-// ReadFile implements db.FileStore.
 func (d *Datastore) ReadFile(ctx context.Context, service, name string) (data db.ReadSeekerCloser, modtime time.Time, err error) {
 	var b []byte
 	var ts int64

--- a/fleetspeak/src/server/mysql/messagestore.go
+++ b/fleetspeak/src/server/mysql/messagestore.go
@@ -211,7 +211,6 @@ func toMessageProto(m *dbMessage) (*fspb.Message, error) {
 	return pm, nil
 }
 
-// StoreMessages implements db.MessageStore.
 func (d *Datastore) StoreMessages(ctx context.Context, msgs []*fspb.Message, contact db.ContactID) error {
 	ids := make([]string, 0, len(msgs))
 
@@ -352,7 +351,6 @@ func (d *Datastore) tryStoreMessage(ctx context.Context, tx *sql.Tx, dbm *dbMess
 	return nil
 }
 
-// GetMessages implements db.MessageStore.
 func (d *Datastore) GetMessages(ctx context.Context, ids []common.MessageID, wantData bool) ([]*fspb.Message, error) {
 	res := make([]*fspb.Message, 0, len(ids))
 	err := d.runInTx(ctx, true, func(tx *sql.Tx) error {
@@ -417,7 +415,6 @@ func (d *Datastore) GetMessages(ctx context.Context, ids []common.MessageID, wan
 	return res, err
 }
 
-// GetMessageResult implements db.MessageStore.
 func (d *Datastore) GetMessageResult(ctx context.Context, id common.MessageID) (*fspb.MessageResult, error) {
 	var ret *fspb.MessageResult
 
@@ -452,7 +449,6 @@ func (d *Datastore) GetMessageResult(ctx context.Context, id common.MessageID) (
 	return ret, err
 }
 
-// ClientMessagesForProcessing implements db.MessageStore.
 func (d *Datastore) ClientMessagesForProcessing(ctx context.Context, id common.ClientID, lim int) ([]*fspb.Message, error) {
 	if id == (common.ClientID{}) {
 		return nil, errors.New("a client is required")
@@ -677,7 +673,6 @@ type messageLooper struct {
 	loopDone         chan struct{}
 }
 
-// RegisterMessageProcessor implements db.MessageStore.
 func (d *Datastore) RegisterMessageProcessor(mp db.MessageProcessor) {
 	if d.looper != nil {
 		log.Warning("Attempt to register a second MessageProcessor.")
@@ -693,7 +688,6 @@ func (d *Datastore) RegisterMessageProcessor(mp db.MessageProcessor) {
 	go d.looper.messageProcessingLoop()
 }
 
-// StopMessageProcessor implements db.MessageStore.
 func (d *Datastore) StopMessageProcessor() {
 	if d.looper != nil {
 		d.looper.stop()

--- a/fleetspeak/src/server/sertesting/context.go
+++ b/fleetspeak/src/server/sertesting/context.go
@@ -29,7 +29,6 @@ type FakeContext struct {
 	ClientData   map[common.ClientID]*db.ClientData
 }
 
-// Send implements sevice.Context.
 func (c *FakeContext) Send(ctx context.Context, m *fspb.Message) error {
 	select {
 	case c.SentMessages <- m:
@@ -39,7 +38,6 @@ func (c *FakeContext) Send(ctx context.Context, m *fspb.Message) error {
 	}
 }
 
-// GetClientData implements sevice.Context.
 func (c *FakeContext) GetClientData(_ context.Context, id common.ClientID) (*db.ClientData, error) {
 	return c.ClientData[id], nil
 }

--- a/fleetspeak/src/server/service/service.go
+++ b/fleetspeak/src/server/service/service.go
@@ -58,7 +58,8 @@ type Context interface {
 	GetClientData(context.Context, common.ClientID) (*db.ClientData, error)
 }
 
-// ServiceFactory creates a server service for the provided configuration.
+// A Factory is a function which creates a server service for the provided
+// configuration.
 type Factory func(*spb.ServiceConfig) (Service, error)
 
 // NOOPFactory is a services.Factory that creates a service which drops all messages.

--- a/fleetspeak/src/server/sqlite/broadcaststore.go
+++ b/fleetspeak/src/server/sqlite/broadcaststore.go
@@ -99,7 +99,6 @@ func toBroadcastProto(b *dbBroadcast) (*spb.Broadcast, error) {
 	return ret, nil
 }
 
-// CreateBroadcast implements db.BroadcastStore.
 func (d *Datastore) CreateBroadcast(ctx context.Context, b *spb.Broadcast, limit uint64) error {
 	d.l.Lock()
 	defer d.l.Unlock()
@@ -142,7 +141,6 @@ func (d *Datastore) CreateBroadcast(ctx context.Context, b *spb.Broadcast, limit
 	})
 }
 
-// SetBroadcastLimit implements db.BroadcastStore.
 func (d *Datastore) SetBroadcastLimit(ctx context.Context, id ids.BroadcastID, limit uint64) error {
 	d.l.Lock()
 	defer d.l.Unlock()
@@ -152,7 +150,6 @@ func (d *Datastore) SetBroadcastLimit(ctx context.Context, id ids.BroadcastID, l
 	})
 }
 
-// SaveBroadcastMessage implements db.BroadcastStore.
 func (d *Datastore) SaveBroadcastMessage(ctx context.Context, msg *fspb.Message, bID ids.BroadcastID, cID common.ClientID, aID ids.AllocationID) error {
 	d.l.Lock()
 	defer d.l.Unlock()
@@ -191,7 +188,6 @@ func (d *Datastore) SaveBroadcastMessage(ctx context.Context, msg *fspb.Message,
 	})
 }
 
-// ListActiveBroadcasts implements db.BroadcastStore.
 func (d *Datastore) ListActiveBroadcasts(ctx context.Context) ([]*db.BroadcastInfo, error) {
 	d.l.Lock()
 	defer d.l.Unlock()
@@ -279,7 +275,6 @@ func (d *Datastore) ListActiveBroadcasts(ctx context.Context) ([]*db.BroadcastIn
 	return ret, err
 }
 
-// ListSentBroadcasts implements db.BroadcastStore.
 func (d *Datastore) ListSentBroadcasts(ctx context.Context, id common.ClientID) ([]ids.BroadcastID, error) {
 	d.l.Lock()
 	defer d.l.Unlock()
@@ -307,7 +302,6 @@ func (d *Datastore) ListSentBroadcasts(ctx context.Context, id common.ClientID) 
 	return res, nil
 }
 
-// CreateAllocation implements db.BroadcastStore.
 func (d *Datastore) CreateAllocation(ctx context.Context, id ids.BroadcastID, frac float32, expiry time.Time) (*db.AllocationInfo, error) {
 	d.l.Lock()
 	defer d.l.Unlock()
@@ -357,7 +351,6 @@ func (d *Datastore) CreateAllocation(ctx context.Context, id ids.BroadcastID, fr
 	return ret, err
 }
 
-// CleanupAllocation implements db.BroadcastStore.
 func (d *Datastore) CleanupAllocation(ctx context.Context, bID ids.BroadcastID, aID ids.AllocationID) error {
 	d.l.Lock()
 	defer d.l.Unlock()

--- a/fleetspeak/src/server/sqlite/clientstore.go
+++ b/fleetspeak/src/server/sqlite/clientstore.go
@@ -37,7 +37,6 @@ const (
 	bytesToMIB = 1.0 / float64(1<<20)
 )
 
-// ListClients implements db.ClientStore.
 func (d *Datastore) ListClients(ctx context.Context, ids []common.ClientID) ([]*spb.Client, error) {
 	d.l.Lock()
 	defer d.l.Unlock()
@@ -124,7 +123,6 @@ func (d *Datastore) ListClients(ctx context.Context, ids []common.ClientID) ([]*
 	return ret, err
 }
 
-// GetClientData implements db.ClientStore.
 func (d *Datastore) GetClientData(ctx context.Context, id common.ClientID) (*db.ClientData, error) {
 	d.l.Lock()
 	defer d.l.Unlock()
@@ -162,7 +160,6 @@ func (d *Datastore) GetClientData(ctx context.Context, id common.ClientID) (*db.
 	return cd, err
 }
 
-// AddClient implements db.ClientStore.
 func (d *Datastore) AddClient(ctx context.Context, id common.ClientID, data *db.ClientData) error {
 	d.l.Lock()
 	defer d.l.Unlock()
@@ -180,7 +177,6 @@ func (d *Datastore) AddClient(ctx context.Context, id common.ClientID, data *db.
 	})
 }
 
-// AddClientLabel implements db.ClientStore.
 func (d *Datastore) AddClientLabel(ctx context.Context, id common.ClientID, l *fspb.Label) error {
 	d.l.Lock()
 	defer d.l.Unlock()
@@ -188,7 +184,6 @@ func (d *Datastore) AddClientLabel(ctx context.Context, id common.ClientID, l *f
 	return err
 }
 
-// RemoveClientLabel implements db.ClientStore.
 func (d *Datastore) RemoveClientLabel(ctx context.Context, id common.ClientID, l *fspb.Label) error {
 	d.l.Lock()
 	defer d.l.Unlock()
@@ -196,13 +191,11 @@ func (d *Datastore) RemoveClientLabel(ctx context.Context, id common.ClientID, l
 	return err
 }
 
-// BlacklistClient implements db.ClientStore
 func (d *Datastore) BlacklistClient(ctx context.Context, id common.ClientID) error {
 	_, err := d.db.ExecContext(ctx, "UPDATE clients SET blacklisted=1 WHERE client_id=?", id.String())
 	return err
 }
 
-// RecordClientContact implements db.ClientStore.
 func (d *Datastore) RecordClientContact(ctx context.Context, cid common.ClientID, nonceSent, nonceReceived uint64, addr string) (db.ContactID, error) {
 	d.l.Lock()
 	defer d.l.Unlock()
@@ -266,7 +259,6 @@ func (d *Datastore) ListClientContacts(ctx context.Context, id common.ClientID) 
 	return res, nil
 }
 
-// LinkMessagesToContact implements db.ClientStore.
 func (d *Datastore) LinkMessagesToContact(ctx context.Context, contact db.ContactID, ids []common.MessageID) error {
 	c, err := strconv.ParseUint(string(contact), 16, 64)
 	if err != nil {
@@ -286,7 +278,6 @@ func (d *Datastore) LinkMessagesToContact(ctx context.Context, contact db.Contac
 	})
 }
 
-// RecordResourceUsageData implements db.ClientStore.
 func (d *Datastore) RecordResourceUsageData(ctx context.Context, id common.ClientID, rud mpb.ResourceUsageData) error {
 	d.l.Lock()
 	defer d.l.Unlock()
@@ -318,7 +309,6 @@ func (d *Datastore) RecordResourceUsageData(ctx context.Context, id common.Clien
 	})
 }
 
-// FetchResourceUsageRecords implements db.ClientStore.
 func (d *Datastore) FetchResourceUsageRecords(ctx context.Context, id common.ClientID, limit int) ([]*spb.ClientResourceUsageRecord, error) {
 	var records []*spb.ClientResourceUsageRecord
 	err := d.runInTx(func(tx *sql.Tx) error {

--- a/fleetspeak/src/server/sqlite/filestore.go
+++ b/fleetspeak/src/server/sqlite/filestore.go
@@ -25,7 +25,6 @@ import (
 	"github.com/google/fleetspeak/fleetspeak/src/server/db"
 )
 
-// StoreFile implements db.FileStore.
 func (d *Datastore) StoreFile(ctx context.Context, service, name string, data io.Reader) error {
 	b, err := ioutil.ReadAll(data)
 	if err != nil {
@@ -40,7 +39,6 @@ func (d *Datastore) StoreFile(ctx context.Context, service, name string, data io
 	})
 }
 
-// StatFile implements db.FileStore.
 func (d *Datastore) StatFile(ctx context.Context, service, name string) (time.Time, error) {
 	d.l.Lock()
 	defer d.l.Unlock()
@@ -49,16 +47,12 @@ func (d *Datastore) StatFile(ctx context.Context, service, name string) (time.Ti
 
 	err := d.runInTx(func(tx *sql.Tx) error {
 		row := tx.QueryRowContext(ctx, "SELECT modified_time_nanos FROM files WHERE service = ? AND name = ?", service, name)
-		if err := row.Scan(&ts); err != nil {
-			return err
-		}
-		return nil
+		return row.Scan(&ts)
 	})
 
 	return time.Unix(0, ts).UTC(), err
 }
 
-// ReadFile implements db.FileStore.
 func (d *Datastore) ReadFile(ctx context.Context, service, name string) (data db.ReadSeekerCloser, modtime time.Time, err error) {
 	d.l.Lock()
 	defer d.l.Unlock()

--- a/fleetspeak/src/server/sqlite/messagestore.go
+++ b/fleetspeak/src/server/sqlite/messagestore.go
@@ -210,7 +210,6 @@ func toMessageProto(m *dbMessage) (*fspb.Message, error) {
 	return pm, nil
 }
 
-// StoreMessages implements db.MessageStore.
 func (d *Datastore) StoreMessages(ctx context.Context, msgs []*fspb.Message, contact db.ContactID) error {
 	d.l.Lock()
 	defer d.l.Unlock()
@@ -348,7 +347,6 @@ func (d *Datastore) tryStoreMessage(ctx context.Context, tx *sql.Tx, dbm *dbMess
 	return nil
 }
 
-// GetMessages implements db.MessageStore.
 func (d *Datastore) GetMessages(ctx context.Context, ids []common.MessageID, wantData bool) ([]*fspb.Message, error) {
 	d.l.Lock()
 	defer d.l.Unlock()
@@ -415,7 +413,6 @@ func (d *Datastore) GetMessages(ctx context.Context, ids []common.MessageID, wan
 	return res, err
 }
 
-// GetMessageStatus implements db.MessageStore.
 func (d *Datastore) GetMessageResult(ctx context.Context, id common.MessageID) (*fspb.MessageResult, error) {
 	d.l.Lock()
 	defer d.l.Unlock()
@@ -541,7 +538,6 @@ type messageLooper struct {
 	loopDone         chan struct{}
 }
 
-// RegisterMessageProcessor implements db.MessageStore.
 func (d *Datastore) RegisterMessageProcessor(mp db.MessageProcessor) {
 	if d.looper != nil {
 		log.Warning("Attempt to register a second MessageProcessor.")
@@ -557,7 +553,6 @@ func (d *Datastore) RegisterMessageProcessor(mp db.MessageProcessor) {
 	go d.looper.messageProcessingLoop()
 }
 
-// StopMessageProcessor implements db.MessageStore.
 func (d *Datastore) StopMessageProcessor() {
 	if d.looper != nil {
 		d.looper.stop()

--- a/fleetspeak/src/server/testserver/testserver.go
+++ b/fleetspeak/src/server/testserver/testserver.go
@@ -56,16 +56,13 @@ type FakeCommunicator struct {
 	Dest *Server
 }
 
-// Setup implements comms.Communicator.
 func (c FakeCommunicator) Setup(cc comms.Context) error {
 	c.Dest.CC = cc
 	return nil
 }
 
-// Start implements comms.Communicator.
 func (c FakeCommunicator) Start() error { return nil }
 
-// Stop implements comms.Communicator.
 func (c FakeCommunicator) Stop() {}
 
 // Make creates a server.Server using the provided communicators. It creates and


### PR DESCRIPTION
Fix some linter errors.
Remove some linter inspired 'pointless' method comments.
For the purposes of this PR a method comment is 'pointless' when:
-The struct exists primarily to implement an interface and this is clear from the struct comment.
-The method implements a method of this interface.
-There is nothing interesting to say about how it implements the interface, meaning that the comment is simply "(method) implements (interface)".
  