### PR TITLE
Restructure client cache interface. Make more paranoid.

### DIFF
--- a/fleetspeak/src/server/db/store.go
+++ b/fleetspeak/src/server/db/store.go
@@ -37,6 +37,8 @@ import (
 	"github.com/google/fleetspeak/fleetspeak/src/common"
 	"github.com/google/fleetspeak/fleetspeak/src/server/ids"
 
+	"github.com/golang/protobuf/proto"
+
 	tpb "github.com/golang/protobuf/ptypes/timestamp"
 	fspb "github.com/google/fleetspeak/fleetspeak/src/common/proto/fleetspeak"
 	mpb "github.com/google/fleetspeak/fleetspeak/src/common/proto/fleetspeak_monitoring"
@@ -69,6 +71,20 @@ type ClientData struct {
 	// Whether the client_id has been blacklisted. Once blacklisted any contact
 	// from this client_id will result in an rekey request.
 	Blacklisted bool
+}
+
+// Clone returns a deep copy.
+func (d *ClientData) Clone() *ClientData {
+	ret := &ClientData{
+		Blacklisted: d.Blacklisted,
+	}
+	ret.Key = append(ret.Key, d.Key...)
+
+	ret.Labels = make([]*fspb.Label, 0, len(d.Labels))
+	for _, l := range d.Labels {
+		ret.Labels = append(ret.Labels, proto.Clone(l).(*fspb.Label))
+	}
+	return ret
 }
 
 // A ContactID identifies a communication with a client. The form is determined

--- a/fleetspeak/src/server/internal/services/manager.go
+++ b/fleetspeak/src/server/internal/services/manager.go
@@ -306,14 +306,9 @@ func (s *liveService) Send(ctx context.Context, m *fspb.Message) error {
 
 // GetClientData implements service.Context.
 func (s *liveService) GetClientData(ctx context.Context, id common.ClientID) (*db.ClientData, error) {
-	cd := s.manager.cc.Get(id)
-	if cd == nil {
-		var err error
-		cd, err = s.manager.dataStore.GetClientData(ctx, id)
-		if err != nil {
-			return nil, err
-		}
-		s.manager.cc.Update(id, cd)
+	cd, _, err := s.manager.cc.GetOrRead(ctx, id, s.manager.dataStore)
+	if err != nil {
+		return nil, err
 	}
 	return cd, nil
 }


### PR DESCRIPTION
Centralize the database reading/updating logic. Clone records going in and out to eliminate the possibility of unexpected aliasing corrupting the cache.