### PR TITLE
Pass ValidationInfo through to the stats collector.

### DIFF
--- a/fleetspeak/src/inttesting/integrationtest/frr.go
+++ b/fleetspeak/src/inttesting/integrationtest/frr.go
@@ -100,7 +100,7 @@ func (c *statsCounter) DatastoreOperation(start, end time.Time, operation string
 	atomic.AddInt64(&c.datastoreOperations, 1)
 }
 
-func (c *statsCounter) ResourceUsageDataReceived(cd *db.ClientData, rud mpb.ResourceUsageData) {
+func (c *statsCounter) ResourceUsageDataReceived(cd *db.ClientData, rud mpb.ResourceUsageData, v *fspb.ValidationInfo) {
 }
 
 // FRRIntegrationTest spins up a small FRR installation, backed by the provided datastore

--- a/fleetspeak/src/server/internal/services/system_service.go
+++ b/fleetspeak/src/server/internal/services/system_service.go
@@ -80,7 +80,7 @@ func (s *systemService) ProcessMessage(ctx context.Context, m *fspb.Message) err
 	case "ClientInfo":
 		return s.processClientInfo(ctx, cid, m.Data)
 	case "ResourceUsage":
-		return s.processResourceUsage(ctx, cid, m.Data)
+		return s.processResourceUsage(ctx, cid, m.Data, m.ValidationInfo)
 	default:
 	}
 
@@ -236,7 +236,7 @@ func (s *systemService) processClientInfo(ctx context.Context, cid common.Client
 }
 
 // processResourceUsage processes a ResourceUsageData message.
-func (s *systemService) processResourceUsage(ctx context.Context, cid common.ClientID, d *apb.Any) error {
+func (s *systemService) processResourceUsage(ctx context.Context, cid common.ClientID, d *apb.Any, v *fspb.ValidationInfo) error {
 	var rud mpb.ResourceUsageData
 	if err := ptypes.UnmarshalAny(d, &rud); err != nil {
 		return fmt.Errorf("unable to unmarshal data as ResourceUsageData: %v", err)
@@ -246,7 +246,7 @@ func (s *systemService) processResourceUsage(ctx context.Context, cid common.Cli
 	if err != nil {
 		log.Errorf("Failed to get client data for %v: %v", cid, err)
 	}
-	s.stats.ResourceUsageDataReceived(cd, rud)
+	s.stats.ResourceUsageDataReceived(cd, rud, v)
 	if err := s.datastore.RecordResourceUsageData(ctx, cid, rud); err != nil {
 		err = fmt.Errorf("failed to write resource-usage data: %v", err)
 		return err

--- a/fleetspeak/src/server/stats.go
+++ b/fleetspeak/src/server/stats.go
@@ -53,7 +53,7 @@ func (s noopStatsCollector) ClientPoll(info stats.PollInfo) {
 func (s noopStatsCollector) DatastoreOperation(start, end time.Time, operation string, result error) {
 }
 
-func (s noopStatsCollector) ResourceUsageDataReceived(cd *db.ClientData, rud mpb.ResourceUsageData) {
+func (s noopStatsCollector) ResourceUsageDataReceived(cd *db.ClientData, rud mpb.ResourceUsageData, v *fspb.ValidationInfo) {
 }
 
 // A MonitoredDatastore wraps a base Datastore and collects statistics about all

--- a/fleetspeak/src/server/stats/collector.go
+++ b/fleetspeak/src/server/stats/collector.go
@@ -77,5 +77,5 @@ type Collector interface {
 	DatastoreOperation(start, end time.Time, operation string, result error)
 
 	// ResourceUsageDataReceived is called every time a client-resource-usage proto is received.
-	ResourceUsageDataReceived(cd *db.ClientData, rud mpb.ResourceUsageData)
+	ResourceUsageDataReceived(cd *db.ClientData, rud mpb.ResourceUsageData, v *fspb.ValidationInfo)
 }


### PR DESCRIPTION
Data collected through ResourceUsageData is a nice way to see currently connected client demographics. This allows those demographics to include how much validation the clients are managing.