### PR TITLE
Fix typo in grpcservice python client library.

### DIFF
--- a/fleetspeak/src/server/grpcservice/client/client.py
+++ b/fleetspeak/src/server/grpcservice/client/client.py
@@ -166,7 +166,7 @@ class OutgoingConnection(object):
     while True:
       try:
         return func(timeout)
-      except grpcs.RpcError:
+      except grpc.RpcError:
         if time.time() + sleep > deadline:
           raise
         time.sleep(sleep)


### PR DESCRIPTION
Also add a bit more of a unit test.