### PR TITLE
Relaxes the fleetspeak socket ownership check by the library.

### DIFF
--- a/fleetspeak/src/client/socketservice/checks/sock_checks_unix.go
+++ b/fleetspeak/src/client/socketservice/checks/sock_checks_unix.go
@@ -98,10 +98,18 @@ func checkUnixOwnership(fi os.FileInfo) error {
 	}
 
 	gid := os.Getgid()
-	// On some platforms (e.g. Darwin) groups 1 and 0 are mostly interchangeable.
-	if gid != int(st.Gid) && st.Gid > 1 && runtime.GOOS == "darwin" {
-		return fmt.Errorf("unexpected gid %d (wanted %d or <1 (system groups))", st.Gid, gid)
+	switch runtime.GOOS {
+	case "darwin":
+		// On macOS groups 1 and 0 are mostly interchangeable.
+		if gid != int(st.Gid) && st.Gid > 1 {
+			return fmt.Errorf("unexpected gid %d (wanted %d or <1 (system groups))", st.Gid, gid)
+		}
+	default:
+		if gid != int(st.Gid) {
+			return fmt.Errorf("unexpected gid %d (wanted %d)", st.Gid, gid)
+		}
 	}
 
 	return nil
 }
+


### PR DESCRIPTION
Also differentiates permanent failures from temporary ones (IsNotExist).
Possibly, this could be relaxed further, but this at least allows it to run on mac without special massaging with respect to wheel vs admin vs daemon groups.