### PR TITLE
Limit service failure-reason lengths in the DB.

### DIFF
--- a/fleetspeak/src/client/daemonservice/execution/execution_test.go
+++ b/fleetspeak/src/client/daemonservice/execution/execution_test.go
@@ -196,7 +196,7 @@ func TestStats(t *testing.T) {
 		OutChan: make(chan *fspb.Message, 2000),
 	}
 	dsc := &dspb.Config{
-		Argv: []string{testClient(), "--mode=loopback"},
+		Argv:                                  []string{testClient(), "--mode=loopback"},
 		ResourceMonitoringSampleSize:          2,
 		ResourceMonitoringSamplePeriodSeconds: 1,
 	}

--- a/fleetspeak/src/client/socketservice/checks/sock_checks_unix.go
+++ b/fleetspeak/src/client/socketservice/checks/sock_checks_unix.go
@@ -29,7 +29,6 @@ import (
 	"syscall"
 )
 
-
 // CheckSocketFile ensures the naming, mode (perms, filetype) and ownership
 // (uid, gid) of a Unix socket match what we create in a Fleetspeak socket
 // service. This gives us some extra security. Note that using os.Lstat here
@@ -112,4 +111,3 @@ func checkUnixOwnership(fi os.FileInfo) error {
 
 	return nil
 }
-

--- a/fleetspeak/src/comtesting/server_cert.go
+++ b/fleetspeak/src/comtesting/server_cert.go
@@ -45,14 +45,14 @@ func ServerCert() (cert []byte, key []byte, err error) {
 	}
 
 	tmpl := x509.Certificate{
-		Version:      1,
-		SerialNumber: serialNumber,
-		Subject:      pkix.Name{CommonName: "Test server"},
-		NotBefore:    time.Now().Add(-time.Minute),
-		NotAfter:     time.Now().Add(24 * time.Hour),
-		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		IsCA:         true,
+		Version:               1,
+		SerialNumber:          serialNumber,
+		Subject:               pkix.Name{CommonName: "Test server"},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IsCA:                  true,
 		BasicConstraintsValid: true,
 		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1), net.ParseIP("::1")},
 	}

--- a/fleetspeak/src/demo/certgen/certgen.go
+++ b/fleetspeak/src/demo/certgen/certgen.go
@@ -135,10 +135,10 @@ func createCACert() bool {
 			Country:      caCountry,
 			Organization: caOrganization,
 			CommonName:   *caCommonName},
-		NotBefore: time.Now(),
-		NotAfter:  time.Now().Add(*caExpiresAfter),
-		KeyUsage:  x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		IsCA:      true,
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(*caExpiresAfter),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		IsCA:                  true,
 		BasicConstraintsValid: true,
 	}
 	dc, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, privKey.Public(), privKey)
@@ -206,11 +206,11 @@ func createServerCert() {
 			Country:      serverCountry,
 			Organization: serverOrganization,
 			CommonName:   *serverCommonName},
-		NotBefore:   time.Now(),
-		NotAfter:    time.Now().Add(*serverExpiresAfter),
-		KeyUsage:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		IsCA:        false,
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(*serverExpiresAfter),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IsCA:                  false,
 		BasicConstraintsValid: true,
 	}
 	for _, h := range serverHostnames {

--- a/fleetspeak/src/demo/configurator/configurator.go
+++ b/fleetspeak/src/demo/configurator/configurator.go
@@ -160,14 +160,14 @@ func createServerCert() bool {
 	// Create a self signed certificate good for 2 years, valid for the
 	// targeted hosts.
 	tmpl := x509.Certificate{
-		Version:      1,
-		SerialNumber: serialNumber,
-		Subject:      pkix.Name{CommonName: *certCommonName},
-		NotBefore:    time.Now(),
-		NotAfter:     time.Now().Add(2 * 24 * 365 * time.Hour),
-		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		IsCA:         true,
+		Version:               1,
+		SerialNumber:          serialNumber,
+		Subject:               pkix.Name{CommonName: *certCommonName},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(2 * 24 * 365 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IsCA:                  true,
 		BasicConstraintsValid: true,
 	}
 	for _, hp := range serverHostPorts {

--- a/fleetspeak/src/server/servertests/comms_test.go
+++ b/fleetspeak/src/server/servertests/comms_test.go
@@ -31,10 +31,10 @@ import (
 	tpb "github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/google/fleetspeak/fleetspeak/src/common"
 	"github.com/google/fleetspeak/fleetspeak/src/server/db"
-	"github.com/google/fleetspeak/fleetspeak/src/server/sertesting"
-	"github.com/google/fleetspeak/fleetspeak/src/server/testserver"
 	"github.com/google/fleetspeak/fleetspeak/src/server/internal/services"
+	"github.com/google/fleetspeak/fleetspeak/src/server/sertesting"
 	"github.com/google/fleetspeak/fleetspeak/src/server/service"
+	"github.com/google/fleetspeak/fleetspeak/src/server/testserver"
 
 	fspb "github.com/google/fleetspeak/fleetspeak/src/common/proto/fleetspeak"
 )
@@ -264,7 +264,7 @@ func TestBlacklist(t *testing.T) {
 
 // errorService is a Fleetspeak service.Service that returns a specified
 // error every time Service.ProcessMessage() is called.
-type errorService struct{
+type errorService struct {
 	e error
 }
 
@@ -272,10 +272,9 @@ func (s errorService) Start(sctx service.Context) error                         
 func (s errorService) ProcessMessage(ctx context.Context, m *fspb.Message) error { return s.e }
 func (s errorService) Stop() error                                               { return nil }
 
-
 func TestServiceError(t *testing.T) {
 	ctx := context.Background()
-	testService := errorService{errors.New(strings.Repeat("a", services.MaxServiceFailureReasonLength + 1))}
+	testService := errorService{errors.New(strings.Repeat("a", services.MaxServiceFailureReasonLength+1))}
 	serverWrapper := testserver.MakeWithService(t, "server", "ServiceError", testService)
 	defer serverWrapper.S.Stop()
 
@@ -289,7 +288,7 @@ func TestServiceError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	clientMessage := &fspb.Message {
+	clientMessage := &fspb.Message{
 		Source: &fspb.Address{
 			ClientId:    clientID.Bytes(),
 			ServiceName: "TestService",
@@ -302,7 +301,7 @@ func TestServiceError(t *testing.T) {
 	}
 	contactData := &fspb.ContactData{
 		SequencingNonce: 5,
-		Messages: []*fspb.Message{clientMessage},
+		Messages:        []*fspb.Message{clientMessage},
 	}
 	serializedContactData, err := proto.Marshal(contactData)
 	if err != nil {
@@ -313,7 +312,7 @@ func TestServiceError(t *testing.T) {
 		ctx,
 		&net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 123},
 		clientPublicKey,
-		&fspb.WrappedContactData{ContactData:serializedContactData},
+		&fspb.WrappedContactData{ContactData: serializedContactData},
 		false); err != nil {
 		t.Fatalf("InitializeConnection() failed: %v", err)
 	}

--- a/fleetspeak/src/server/servertests/comms_test.go
+++ b/fleetspeak/src/server/servertests/comms_test.go
@@ -22,7 +22,9 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"errors"
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
@@ -31,6 +33,8 @@ import (
 	"github.com/google/fleetspeak/fleetspeak/src/server/db"
 	"github.com/google/fleetspeak/fleetspeak/src/server/sertesting"
 	"github.com/google/fleetspeak/fleetspeak/src/server/testserver"
+	"github.com/google/fleetspeak/fleetspeak/src/server/internal/services"
+	"github.com/google/fleetspeak/fleetspeak/src/server/service"
 
 	fspb "github.com/google/fleetspeak/fleetspeak/src/common/proto/fleetspeak"
 )
@@ -255,5 +259,73 @@ func TestBlacklist(t *testing.T) {
 	}
 	if !bytes.Equal(msgs[0].MessageId, msg.MessageId) || msgs[0].MessageType != "RekeyRequest" {
 		t.Errorf("GetMessage([%v]) did not return expected RekeyRequest, want: %+v got: %+v", mid, msg, msgs[0])
+	}
+}
+
+// errorService is a Fleetspeak service.Service that returns a specified
+// error every time Service.ProcessMessage() is called.
+type errorService struct{
+	e error
+}
+
+func (s errorService) Start(sctx service.Context) error                          { return nil }
+func (s errorService) ProcessMessage(ctx context.Context, m *fspb.Message) error { return s.e }
+func (s errorService) Stop() error                                               { return nil }
+
+
+func TestServiceError(t *testing.T) {
+	ctx := context.Background()
+	testService := errorService{errors.New(strings.Repeat("a", services.MaxServiceFailureReasonLength + 1))}
+	serverWrapper := testserver.MakeWithService(t, "server", "ServiceError", testService)
+	defer serverWrapper.S.Stop()
+
+	clientPrivateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientPublicKey := clientPrivateKey.Public()
+
+	clientID, err := common.MakeClientID(clientPublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientMessage := &fspb.Message {
+		Source: &fspb.Address{
+			ClientId:    clientID.Bytes(),
+			ServiceName: "TestService",
+		},
+		Destination: &fspb.Address{
+			ServiceName: "TestService",
+		},
+		SourceMessageId: []byte("AAABBBCCC"),
+		MessageType:     "TestMessage",
+	}
+	contactData := &fspb.ContactData{
+		SequencingNonce: 5,
+		Messages: []*fspb.Message{clientMessage},
+	}
+	serializedContactData, err := proto.Marshal(contactData)
+	if err != nil {
+		t.Fatalf("Unable to marshal contact data: %v", err)
+	}
+
+	if _, _, _, err = serverWrapper.CC.InitializeConnection(
+		ctx,
+		&net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 123},
+		clientPublicKey,
+		&fspb.WrappedContactData{ContactData:serializedContactData},
+		false); err != nil {
+		t.Fatalf("InitializeConnection() failed: %v", err)
+	}
+
+	messageID := common.MakeMessageID(clientMessage.Source, clientMessage.SourceMessageId)
+	messageResult, err := serverWrapper.DS.GetMessageResult(ctx, messageID)
+	if err != nil {
+		t.Fatalf("Failed to get message result: %v", err)
+	}
+
+	expectedFailedReason := strings.Repeat("a", services.MaxServiceFailureReasonLength-3) + "..."
+	if messageResult.FailedReason != expectedFailedReason {
+		t.Errorf("Unexpected failure reason: got [%v], want [%v]", messageResult.FailedReason, expectedFailedReason)
 	}
 }

--- a/fleetspeak/src/server/servertests/comms_test.go
+++ b/fleetspeak/src/server/servertests/comms_test.go
@@ -265,11 +265,11 @@ func TestBlacklist(t *testing.T) {
 // errorService is a Fleetspeak service.Service that returns a specified
 // error every time Service.ProcessMessage() is called.
 type errorService struct {
-	e error
+	err error
 }
 
 func (s errorService) Start(sctx service.Context) error                          { return nil }
-func (s errorService) ProcessMessage(ctx context.Context, m *fspb.Message) error { return s.e }
+func (s errorService) ProcessMessage(ctx context.Context, m *fspb.Message) error { return s.err }
 func (s errorService) Stop() error                                               { return nil }
 
 func TestServiceError(t *testing.T) {

--- a/fleetspeak/src/server/servertests/system_service_test.go
+++ b/fleetspeak/src/server/servertests/system_service_test.go
@@ -17,6 +17,7 @@ package servertests_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/google/fleetspeak/fleetspeak/src/common"
 	fspb "github.com/google/fleetspeak/fleetspeak/src/common/proto/fleetspeak"
 	"github.com/google/fleetspeak/fleetspeak/src/server/db"
+	"github.com/google/fleetspeak/fleetspeak/src/server/internal/services"
 	"github.com/google/fleetspeak/fleetspeak/src/server/sertesting"
 	"github.com/google/fleetspeak/fleetspeak/src/server/testserver"
 )
@@ -232,9 +234,10 @@ func TestSystemServiceMessageError(t *testing.T) {
 		MessageType:     "MessageError",
 	}
 	m.MessageId = common.MakeMessageID(m.Source, m.SourceMessageId).Bytes()
+	errorMessage = strings.Repeat("a", services.MaxServiceFailureReasonLength)
 	m.Data, err = ptypes.MarshalAny(&fspb.MessageErrorData{
 		MessageId: mid.Bytes(),
-		Error:     "failed badly",
+		Error:     errorMessage,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -246,5 +249,9 @@ func TestSystemServiceMessageError(t *testing.T) {
 	msg = ts.GetMessage(ctx, mid)
 	if msg.Result == nil {
 		t.Fatal("Added message should now be failed.")
+	}
+	expectedFailedReason = strings.Repeat("a", services.MaxServiceFailureReasonLength-3) + "..."
+	if msg.Result.FailedReason != expectedFailedReason {
+		t.Errorf("Unexpected failure reason: got %v, want %v.", msg.Result.FailedReason, expectedFailedReason)
 	}
 }

--- a/fleetspeak/src/server/servertests/system_service_test.go
+++ b/fleetspeak/src/server/servertests/system_service_test.go
@@ -17,7 +17,6 @@ package servertests_test
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -25,7 +24,6 @@ import (
 	"github.com/google/fleetspeak/fleetspeak/src/common"
 	fspb "github.com/google/fleetspeak/fleetspeak/src/common/proto/fleetspeak"
 	"github.com/google/fleetspeak/fleetspeak/src/server/db"
-	"github.com/google/fleetspeak/fleetspeak/src/server/internal/services"
 	"github.com/google/fleetspeak/fleetspeak/src/server/sertesting"
 	"github.com/google/fleetspeak/fleetspeak/src/server/testserver"
 )
@@ -234,10 +232,9 @@ func TestSystemServiceMessageError(t *testing.T) {
 		MessageType:     "MessageError",
 	}
 	m.MessageId = common.MakeMessageID(m.Source, m.SourceMessageId).Bytes()
-	errorMessage = strings.Repeat("a", services.MaxServiceFailureReasonLength)
 	m.Data, err = ptypes.MarshalAny(&fspb.MessageErrorData{
 		MessageId: mid.Bytes(),
-		Error:     errorMessage,
+		Error:     "failed badly",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -249,9 +246,5 @@ func TestSystemServiceMessageError(t *testing.T) {
 	msg = ts.GetMessage(ctx, mid)
 	if msg.Result == nil {
 		t.Fatal("Added message should now be failed.")
-	}
-	expectedFailedReason = strings.Repeat("a", services.MaxServiceFailureReasonLength-3) + "..."
-	if msg.Result.FailedReason != expectedFailedReason {
-		t.Errorf("Unexpected failure reason: got %v, want %v.", msg.Result.FailedReason, expectedFailedReason)
 	}
 }


### PR DESCRIPTION
Along the way, run gofmt on all files in the repo.
