### PR TITLE
Deployment key removal

### DIFF
--- a/fleetspeak/src/client/client_test.go
+++ b/fleetspeak/src/client/client_test.go
@@ -217,12 +217,6 @@ func TestServiceValidation(t *testing.T) {
 	tmpPath, fin := comtesting.GetTempDir("client_service_validation")
 	defer fin()
 
-	k, err := rsa.GenerateKey(rand.Reader, 4096)
-	if err != nil {
-		t.Fatalf("Unable to generate deployment key: %v", err)
-	}
-	pk := *(k.Public().(*rsa.PublicKey))
-
 	sp := filepath.Join(tmpPath, "services")
 	if err := os.Mkdir(sp, 0777); err != nil {
 		t.Fatalf("Unable to create services path [%s]: %v", sp, err)
@@ -277,8 +271,7 @@ func TestServiceValidation(t *testing.T) {
 
 	cl, err := New(
 		config.Configuration{
-			DeploymentPublicKeys: []rsa.PublicKey{pk},
-			PersistenceHandler:   ph,
+			PersistenceHandler: ph,
 			ClientLabels: []*fspb.Label{
 				{ServiceName: "client", Label: "TestClient"},
 				{ServiceName: "client", Label: "linux"}},

--- a/fleetspeak/src/client/client_test.go
+++ b/fleetspeak/src/client/client_test.go
@@ -17,10 +17,6 @@ package client
 import (
 	"bytes"
 	"context"
-	"crypto"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -235,7 +231,7 @@ func TestServiceValidation(t *testing.T) {
 	}
 
 	// A service which should work.
-	cfg := signServiceConfig(t, k, &fspb.ClientServiceConfig{
+	cfg := signServiceConfig(t, &fspb.ClientServiceConfig{
 		Name:           "FakeService",
 		Factory:        "FakeService",
 		RequiredLabels: []*fspb.Label{{ServiceName: "client", Label: "linux"}},
@@ -244,18 +240,8 @@ func TestServiceValidation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// A service signed with the wrong key - should not be started.
-	bk, err := rsa.GenerateKey(rand.Reader, 4096)
-	if err != nil {
-		t.Fatalf("Unable to generate bad deployment key: %v", err)
-	}
-	cfg = signServiceConfig(t, bk, &fspb.ClientServiceConfig{Name: "FailingServiceBadSig", Factory: "FailingService"})
-	if err := clienttestutils.WriteSignedServiceConfig(sp, "FailingServiceBadSig.signed", cfg); err != nil {
-		t.Fatal(err)
-	}
-
-	// A service signed with the right key, but requiring the wrong label.
-	cfg = signServiceConfig(t, bk, &fspb.ClientServiceConfig{
+	// A service requiring the wrong label.
+	cfg = signServiceConfig(t, &fspb.ClientServiceConfig{
 		Name:           "FailingServiceBadLabel",
 		Factory:        "FailingService",
 		RequiredLabels: []*fspb.Label{{ServiceName: "client", Label: "windows"}},
@@ -383,15 +369,10 @@ func TestTextServiceConfig(t *testing.T) {
 	}
 }
 
-func signServiceConfig(t *testing.T, k *rsa.PrivateKey, cfg *fspb.ClientServiceConfig) *fspb.SignedClientServiceConfig {
+func signServiceConfig(t *testing.T, cfg *fspb.ClientServiceConfig) *fspb.SignedClientServiceConfig {
 	b, err := proto.Marshal(cfg)
 	if err != nil {
 		t.Fatalf("Unable to serialize service config: %v", err)
 	}
-	h := sha256.Sum256(b)
-	sig, err := rsa.SignPSS(rand.Reader, k, crypto.SHA256, h[:], nil)
-	if err != nil {
-		t.Fatalf("Unable to sign service config: %v", err)
-	}
-	return &fspb.SignedClientServiceConfig{ServiceConfig: b, Signature: sig}
+	return &fspb.SignedClientServiceConfig{ServiceConfig: b}
 }

--- a/fleetspeak/src/client/config/config.go
+++ b/fleetspeak/src/client/config/config.go
@@ -16,7 +16,6 @@
 package config
 
 import (
-	"crypto/rsa"
 	"crypto/x509"
 
 	clpb "github.com/google/fleetspeak/fleetspeak/src/client/proto/fleetspeak_client"
@@ -36,13 +35,6 @@ type Configuration struct {
 	//
 	// Hardcoding recommended.
 	TrustedCerts *x509.CertPool
-
-	// DeploymentPublicKeys is used to verify service configuration records. To
-	// configure fleetspeak to run a particular program, it is necessary to sign a
-	// service configuration record with the private part of one of these keys.
-	//
-	// Hardcoding recommended.
-	DeploymentPublicKeys []rsa.PublicKey
 
 	// Servers lists the hosts that the client should attempt to connect to,
 	// should be of the form <hostname>:<port>.

--- a/fleetspeak/src/client/internal/config/manager.go
+++ b/fleetspeak/src/client/internal/config/manager.go
@@ -17,12 +17,9 @@
 package config
 
 import (
-	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/rsa"
-	"crypto/sha256"
 	"crypto/x509"
 	"errors"
 	"fmt"
@@ -230,20 +227,6 @@ func (m *Manager) ClientID() common.ClientID {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 	return m.id
-}
-
-// ValidateServiceConfig checks that a config is correctly signed according to
-// some configured deployment key.
-func (m *Manager) ValidateServiceConfig(sd *fspb.SignedClientServiceConfig) error {
-	var err error
-	for _, k := range m.cfg.DeploymentPublicKeys {
-		hashed := sha256.Sum256(sd.ServiceConfig)
-		err = rsa.VerifyPSS(&k, crypto.SHA256, hashed[:], sd.Signature, nil)
-		if err == nil {
-			return nil
-		}
-	}
-	return err
 }
 
 // RecordRunningService adds name to the list of services which this client is

--- a/fleetspeak/src/client/services.go
+++ b/fleetspeak/src/client/services.go
@@ -66,10 +66,6 @@ func (c *serviceConfiguration) ProcessMessage(ctx context.Context, m *fspb.Messa
 }
 
 func (c *serviceConfiguration) InstallSignedService(sd *fspb.SignedClientServiceConfig) error {
-	if err := c.client.config.ValidateServiceConfig(sd); err != nil {
-		return fmt.Errorf("Unable to verify signature of service config %v, ignoring: %v", sd.Signature, err)
-	}
-
 	var cfg fspb.ClientServiceConfig
 	if err := proto.Unmarshal(sd.ServiceConfig, &cfg); err != nil {
 		return fmt.Errorf("Unable to parse service config [%v], ignoring: %v", sd.Signature, err)

--- a/fleetspeak/src/client/services.go
+++ b/fleetspeak/src/client/services.go
@@ -65,6 +65,12 @@ func (c *serviceConfiguration) ProcessMessage(ctx context.Context, m *fspb.Messa
 	}
 }
 
+// InstallSignedService installs a service provided in signed service
+// configurationf format. Note however that this is meant for backwards
+// compatibility and the signature is not checked.
+//
+// Currently, we assume that service configurations are kept in a secured
+// location.
 func (c *serviceConfiguration) InstallSignedService(sd *fspb.SignedClientServiceConfig) error {
 	var cfg fspb.ClientServiceConfig
 	if err := proto.Unmarshal(sd.ServiceConfig, &cfg); err != nil {


### PR DESCRIPTION
Assumes that configurations stored on disk will be stored securely. Clients should continue to load, e.g. existing signed configs, but won't check signatures.

Some of this functionality can be resurrected when/if we implement FS directed service updates, in that case the check would probably occur on download rather than on load.