### PR TITLE
Address socket-service logspam.

### DIFF
--- a/fleetspeak/src/client/socketservice/client/proxy.go
+++ b/fleetspeak/src/client/socketservice/client/proxy.go
@@ -17,6 +17,7 @@ package client
 
 import (
 	"os"
+	"time"
 
 	log "github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
@@ -25,6 +26,23 @@ import (
 	fcpb "github.com/google/fleetspeak/fleetspeak/src/client/channel/proto/fleetspeak_channel"
 	fspb "github.com/google/fleetspeak/fleetspeak/src/common/proto/fleetspeak"
 )
+
+// Back-off constants for retrying channel connections.
+// Current values will result in the following sequence of
+// delays (seconds, rounded off): [1, 1.5, 2.3, 3.4, 5.0, 7.6, 11.4, 15, 15, 15, ...]
+const(
+	maxChannelRetryDelay = 15 * time.Second
+	channelRetryBackoffFactor = 1.5
+)
+
+func backOffChannelRetryDelay(currentDelay time.Duration) time.Duration {
+	newDelay := time.Duration(float64(currentDelay) * channelRetryBackoffFactor)
+	if newDelay > maxChannelRetryDelay {
+		return maxChannelRetryDelay
+	} else {
+		return newDelay
+	}
+}
 
 // OpenChannel creates a channel.RelentlessChannel to a fleetspeak client
 // through an agreed upon unix domain socket.

--- a/fleetspeak/src/client/socketservice/client/proxy.go
+++ b/fleetspeak/src/client/socketservice/client/proxy.go
@@ -30,8 +30,8 @@ import (
 // Back-off constants for retrying channel connections.
 // Current values will result in the following sequence of
 // delays (seconds, rounded off): [1, 1.5, 2.3, 3.4, 5.0, 7.6, 11.4, 15, 15, 15, ...]
-const(
-	maxChannelRetryDelay = 15 * time.Second
+const (
+	maxChannelRetryDelay      = 15 * time.Second
 	channelRetryBackoffFactor = 1.5
 )
 

--- a/fleetspeak/src/client/socketservice/client/proxy_unix.go
+++ b/fleetspeak/src/client/socketservice/client/proxy_unix.go
@@ -32,6 +32,7 @@ func buildChannel(socketPath string) (*channel.Channel, func()) {
 	var err error
 	var conn *net.UnixConn
 
+	retryDelay := time.Second
 	for {
 		if err = checks.CheckSocketFile(socketPath); err != nil {
 			log.Warningf("failure checking perms of [%s], will retry: %v", socketPath, err)
@@ -45,6 +46,7 @@ func buildChannel(socketPath string) (*channel.Channel, func()) {
 				conn.Close()
 			}
 		}
-		time.Sleep(time.Second)
+		time.Sleep(retryDelay)
+		retryDelay = backOffChannelRetryDelay(retryDelay)
 	}
 }

--- a/fleetspeak/src/client/socketservice/client/proxy_windows.go
+++ b/fleetspeak/src/client/socketservice/client/proxy_windows.go
@@ -33,12 +33,11 @@ func buildChannel(socketPath string) (*channel.Channel, func()) {
 	var err error
 	var conn net.Conn
 
-	timeout := time.Second
+    retryDelay := time.Second
 	for {
 		if err = checks.CheckSocketFile(socketPath); err != nil {
 			log.Warningf("Failure checking perms of [%s], will retry: %v", socketPath, err)
-			time.Sleep(timeout)
-		} else if conn, err = wnixsocket.Dial(socketPath, timeout); err != nil {
+		} else if conn, err = wnixsocket.Dial(socketPath, time.Second); err != nil {
 			log.Warningf("Failed to connect to [%s], will retry: %v", socketPath, err)
 		} else {
 			log.Infof("Connected to [%s]", socketPath)
@@ -49,5 +48,7 @@ func buildChannel(socketPath string) (*channel.Channel, func()) {
 				conn.Close()
 			}
 		}
+		time.Sleep(retryDelay)
+		retryDelay = backOffChannelRetryDelay(retryDelay)
 	}
 }

--- a/fleetspeak/src/client/socketservice/client/proxy_windows.go
+++ b/fleetspeak/src/client/socketservice/client/proxy_windows.go
@@ -33,7 +33,7 @@ func buildChannel(socketPath string) (*channel.Channel, func()) {
 	var err error
 	var conn net.Conn
 
-    retryDelay := time.Second
+	retryDelay := time.Second
 	for {
 		if err = checks.CheckSocketFile(socketPath); err != nil {
 			log.Warningf("Failure checking perms of [%s], will retry: %v", socketPath, err)


### PR DESCRIPTION
On Windows, when the Fleetspeak process dies, socket services on the other side of the connection retry the connection without any delay, which is unintended and generates an enormous amount of log-spam. In addition to addressing this bug, I have added a back-off for retrying channel connections - instead of retrying every second, socket services will wait up to 15 seconds before trying to connect to Fleetspeak again.