### PR TITLE
Tear down the freshly opened channel

### DIFF
--- a/fleetspeak/src/client/socketservice/client/proxy.go
+++ b/fleetspeak/src/client/socketservice/client/proxy.go
@@ -67,6 +67,7 @@ func OpenChannel(socketPath string, version string) *channel.RelentlessChannel {
 				select {
 				case e := <-ch.Err:
 					log.Errorf("Channel failed with error: %v", e)
+					fin()
 					continue L
 				case ch.Out <- m:
 					return ch, fin


### PR DESCRIPTION
We need to tear down this channel before we drop the fin callback on the floor in the next loop iteration.
Thanks a lot @bgalehouse for identifying where the fix should go!

Previously identified symptom: Without calling fin(), the channel leaks 2 goroutines on that codepath, the channel's reader and writer goroutines.