### PR TITLE
Update protoc-gen-go version, run generate_go_py_protos.sh.

### DIFF
--- a/fleetspeak/generate_go_py_protos.sh
+++ b/fleetspeak/generate_go_py_protos.sh
@@ -26,7 +26,7 @@ cd "$(/usr/bin/dirname "$(/bin/readlink -e "${ARGV0}")")"
 # otherwise different developers might keep generating different, possibly
 # conflicting proto files.
 # See https://github.com/golang/protobuf/issues/763
-readonly PROTOC_GEN_GO_VERSION='v1.3.1'
+readonly PROTOC_GEN_GO_VERSION='v1.3.2'
 readonly PROTOC_GEN_GO_DIR="$(go env GOPATH)"/src/github.com/golang/protobuf
 if [[ -z "$(git -C "${PROTOC_GEN_GO_DIR}" branch | grep "${PROTOC_GEN_GO_VERSION}")" ]]; then
   echo "Fetching protoc-gen-go ${PROTOC_GEN_GO_VERSION}."

--- a/fleetspeak/src/client/channel/proto/fleetspeak_channel/channel.pb.go
+++ b/fleetspeak/src/client/channel/proto/fleetspeak_channel/channel.pb.go
@@ -5,9 +5,8 @@ package fleetspeak_channel
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/fleetspeak/src/client/daemonservice/proto/fleetspeak_daemonservice/config.pb.go
+++ b/fleetspeak/src/client/daemonservice/proto/fleetspeak_daemonservice/config.pb.go
@@ -5,10 +5,9 @@ package fleetspeak_daemonservice
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	duration "github.com/golang/protobuf/ptypes/duration"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/fleetspeak/src/client/daemonservice/proto/fleetspeak_daemonservice/messages.pb.go
+++ b/fleetspeak/src/client/daemonservice/proto/fleetspeak_daemonservice/messages.pb.go
@@ -5,9 +5,8 @@ package fleetspeak_daemonservice
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/fleetspeak/src/client/generic/proto/fleetspeak_client_generic/config.pb.go
+++ b/fleetspeak/src/client/generic/proto/fleetspeak_client_generic/config.pb.go
@@ -5,9 +5,8 @@ package fleetspeak_client_generic
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/fleetspeak/src/client/proto/fleetspeak_client/api.pb.go
+++ b/fleetspeak/src/client/proto/fleetspeak_client/api.pb.go
@@ -5,10 +5,9 @@ package fleetspeak_client
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	any "github.com/golang/protobuf/ptypes/any"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/fleetspeak/src/client/proto/fleetspeak_client/client.pb.go
+++ b/fleetspeak/src/client/proto/fleetspeak_client/client.pb.go
@@ -5,9 +5,8 @@ package fleetspeak_client
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/fleetspeak/src/client/socketservice/proto/fleetspeak_socketservice/config.pb.go
+++ b/fleetspeak/src/client/socketservice/proto/fleetspeak_socketservice/config.pb.go
@@ -5,9 +5,8 @@ package fleetspeak_socketservice
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/fleetspeak/src/client/stdinservice/proto/fleetspeak_stdinservice/config.pb.go
+++ b/fleetspeak/src/client/stdinservice/proto/fleetspeak_stdinservice/config.pb.go
@@ -5,9 +5,8 @@ package fleetspeak_stdinservice
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/fleetspeak/src/client/stdinservice/proto/fleetspeak_stdinservice/messages.pb.go
+++ b/fleetspeak/src/client/stdinservice/proto/fleetspeak_stdinservice/messages.pb.go
@@ -5,11 +5,10 @@ package fleetspeak_stdinservice
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	fleetspeak_monitoring "github.com/google/fleetspeak/fleetspeak/src/common/proto/fleetspeak_monitoring"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/fleetspeak/src/common/proto/fleetspeak/common.pb.go
+++ b/fleetspeak/src/common/proto/fleetspeak/common.pb.go
@@ -5,11 +5,10 @@ package fleetspeak
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	any "github.com/golang/protobuf/ptypes/any"
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/fleetspeak/src/common/proto/fleetspeak/system.pb.go
+++ b/fleetspeak/src/common/proto/fleetspeak/system.pb.go
@@ -5,11 +5,10 @@ package fleetspeak
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	any "github.com/golang/protobuf/ptypes/any"
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/fleetspeak/src/common/proto/fleetspeak_monitoring/resource.pb.go
+++ b/fleetspeak/src/common/proto/fleetspeak_monitoring/resource.pb.go
@@ -5,10 +5,9 @@ package fleetspeak_monitoring
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/fleetspeak/src/config/proto/fleetspeak_config/config.pb.go
+++ b/fleetspeak/src/config/proto/fleetspeak_config/config.pb.go
@@ -5,10 +5,9 @@ package fleetspeak_config
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	fleetspeak_components "github.com/google/fleetspeak/fleetspeak/src/server/components/proto/fleetspeak_components"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/fleetspeak/src/demo/proto/fleetspeak_messagesaver/messagesaver.pb.go
+++ b/fleetspeak/src/demo/proto/fleetspeak_messagesaver/messagesaver.pb.go
@@ -5,9 +5,8 @@ package fleetspeak_messagesaver
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/fleetspeak/src/inttesting/frr/proto/fleetspeak_frr/frr.pb.go
+++ b/fleetspeak/src/inttesting/frr/proto/fleetspeak_frr/frr.pb.go
@@ -6,11 +6,12 @@ package fleetspeak_frr
 import (
 	context "context"
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	fleetspeak "github.com/google/fleetspeak/fleetspeak/src/common/proto/fleetspeak"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -535,6 +536,17 @@ type MasterServer interface {
 	// RecordFileResponse records that a FileResponse message was received
 	// by the FS server.
 	RecordFileResponse(context.Context, *FileResponseInfo) (*fleetspeak.EmptyMessage, error)
+}
+
+// UnimplementedMasterServer can be embedded to have forward compatible implementations.
+type UnimplementedMasterServer struct {
+}
+
+func (*UnimplementedMasterServer) RecordTrafficResponse(ctx context.Context, req *MessageInfo) (*fleetspeak.EmptyMessage, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RecordTrafficResponse not implemented")
+}
+func (*UnimplementedMasterServer) RecordFileResponse(ctx context.Context, req *FileResponseInfo) (*fleetspeak.EmptyMessage, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RecordFileResponse not implemented")
 }
 
 func RegisterMasterServer(s *grpc.Server, srv MasterServer) {

--- a/fleetspeak/src/osquery/proto/fleetspeak_osquery/osquery.pb.go
+++ b/fleetspeak/src/osquery/proto/fleetspeak_osquery/osquery.pb.go
@@ -5,9 +5,8 @@ package fleetspeak_osquery
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/fleetspeak/src/server/components/proto/fleetspeak_components/config.pb.go
+++ b/fleetspeak/src/server/components/proto/fleetspeak_components/config.pb.go
@@ -5,9 +5,8 @@ package fleetspeak_components
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/fleetspeak/src/server/grpcservice/proto/fleetspeak_grpcservice/grpcservice.pb.go
+++ b/fleetspeak/src/server/grpcservice/proto/fleetspeak_grpcservice/grpcservice.pb.go
@@ -6,11 +6,12 @@ package fleetspeak_grpcservice
 import (
 	context "context"
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	fleetspeak "github.com/google/fleetspeak/fleetspeak/src/common/proto/fleetspeak"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -142,6 +143,14 @@ func (c *processorClient) Process(ctx context.Context, in *fleetspeak.Message, o
 type ProcessorServer interface {
 	// Process accepts message and processes it.
 	Process(context.Context, *fleetspeak.Message) (*fleetspeak.EmptyMessage, error)
+}
+
+// UnimplementedProcessorServer can be embedded to have forward compatible implementations.
+type UnimplementedProcessorServer struct {
+}
+
+func (*UnimplementedProcessorServer) Process(ctx context.Context, req *fleetspeak.Message) (*fleetspeak.EmptyMessage, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Process not implemented")
 }
 
 func RegisterProcessorServer(s *grpc.Server, srv ProcessorServer) {

--- a/fleetspeak/src/server/proto/fleetspeak_server/admin.pb.go
+++ b/fleetspeak/src/server/proto/fleetspeak_server/admin.pb.go
@@ -6,12 +6,13 @@ package fleetspeak_server
 import (
 	context "context"
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	fleetspeak "github.com/google/fleetspeak/fleetspeak/src/common/proto/fleetspeak"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -868,6 +869,38 @@ type AdminServer interface {
 	// BlacklistClient marks a client_id as invalid, forcing all Fleetspeak
 	// clients using it to rekey.
 	BlacklistClient(context.Context, *BlacklistClientRequest) (*fleetspeak.EmptyMessage, error)
+}
+
+// UnimplementedAdminServer can be embedded to have forward compatible implementations.
+type UnimplementedAdminServer struct {
+}
+
+func (*UnimplementedAdminServer) CreateBroadcast(ctx context.Context, req *CreateBroadcastRequest) (*fleetspeak.EmptyMessage, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateBroadcast not implemented")
+}
+func (*UnimplementedAdminServer) ListActiveBroadcasts(ctx context.Context, req *ListActiveBroadcastsRequest) (*ListActiveBroadcastsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListActiveBroadcasts not implemented")
+}
+func (*UnimplementedAdminServer) ListClients(ctx context.Context, req *ListClientsRequest) (*ListClientsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListClients not implemented")
+}
+func (*UnimplementedAdminServer) ListClientContacts(ctx context.Context, req *ListClientContactsRequest) (*ListClientContactsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListClientContacts not implemented")
+}
+func (*UnimplementedAdminServer) GetMessageStatus(ctx context.Context, req *GetMessageStatusRequest) (*GetMessageStatusResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetMessageStatus not implemented")
+}
+func (*UnimplementedAdminServer) InsertMessage(ctx context.Context, req *fleetspeak.Message) (*fleetspeak.EmptyMessage, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method InsertMessage not implemented")
+}
+func (*UnimplementedAdminServer) StoreFile(ctx context.Context, req *StoreFileRequest) (*fleetspeak.EmptyMessage, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method StoreFile not implemented")
+}
+func (*UnimplementedAdminServer) KeepAlive(ctx context.Context, req *fleetspeak.EmptyMessage) (*fleetspeak.EmptyMessage, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method KeepAlive not implemented")
+}
+func (*UnimplementedAdminServer) BlacklistClient(ctx context.Context, req *BlacklistClientRequest) (*fleetspeak.EmptyMessage, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method BlacklistClient not implemented")
 }
 
 func RegisterAdminServer(s *grpc.Server, srv AdminServer) {

--- a/fleetspeak/src/server/proto/fleetspeak_server/broadcasts.pb.go
+++ b/fleetspeak/src/server/proto/fleetspeak_server/broadcasts.pb.go
@@ -5,12 +5,11 @@ package fleetspeak_server
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	any "github.com/golang/protobuf/ptypes/any"
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	fleetspeak "github.com/google/fleetspeak/fleetspeak/src/common/proto/fleetspeak"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/fleetspeak/src/server/proto/fleetspeak_server/resource.pb.go
+++ b/fleetspeak/src/server/proto/fleetspeak_server/resource.pb.go
@@ -5,10 +5,9 @@ package fleetspeak_server
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/fleetspeak/src/server/proto/fleetspeak_server/server.pb.go
+++ b/fleetspeak/src/server/proto/fleetspeak_server/server.pb.go
@@ -5,10 +5,9 @@ package fleetspeak_server
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	duration "github.com/golang/protobuf/ptypes/duration"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/fleetspeak/src/server/proto/fleetspeak_server/services.pb.go
+++ b/fleetspeak/src/server/proto/fleetspeak_server/services.pb.go
@@ -5,10 +5,9 @@ package fleetspeak_server
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	any "github.com/golang/protobuf/ptypes/any"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.


### PR DESCRIPTION
gofmt undoes changes by protoc-gen-go, and vice versa, so we should not run gofmt
on autogenerated go-proto files.
