### PR TITLE
Making sure DEB installation test works on Travis.

### DIFF
--- a/fleetspeak/server-pkg-tmpl/debian/fleetspeak-server.service
+++ b/fleetspeak/server-pkg-tmpl/debian/fleetspeak-server.service
@@ -6,7 +6,7 @@ Documentation=https://github.com/google/fleetspeak
 [Service]
 User=fleetspeak
 Group=fleetspeak
-ExecStart=/bin/ls -l /etc/fleetspeak-server
+ExecStart=find /
 Restart=always
 
 [Install]

--- a/fleetspeak/server-pkg-tmpl/debian/fleetspeak-server.service
+++ b/fleetspeak/server-pkg-tmpl/debian/fleetspeak-server.service
@@ -4,6 +4,8 @@ After=syslog.target network.target
 Documentation=https://github.com/google/fleetspeak
 
 [Service]
+User=fleetspeak
+Group=fleetspeak
 ExecStart=/usr/bin/fleetspeak-server --services_config /etc/fleetspeak-server/server.services.config --components_config /etc/fleetspeak-server/server.components.config
 Restart=always
 

--- a/fleetspeak/server-pkg-tmpl/debian/fleetspeak-server.service
+++ b/fleetspeak/server-pkg-tmpl/debian/fleetspeak-server.service
@@ -6,7 +6,7 @@ Documentation=https://github.com/google/fleetspeak
 [Service]
 User=fleetspeak
 Group=fleetspeak
-ExecStart=/usr/bin/fleetspeak-server --services_config /etc/fleetspeak-server/server.services.config --components_config /etc/fleetspeak-server/server.components.config
+ExecStart=/bin/ls -l /etc/fleetspeak-server
 Restart=always
 
 [Install]

--- a/fleetspeak/server-pkg-tmpl/debian/fleetspeak-server.service
+++ b/fleetspeak/server-pkg-tmpl/debian/fleetspeak-server.service
@@ -4,9 +4,7 @@ After=syslog.target network.target
 Documentation=https://github.com/google/fleetspeak
 
 [Service]
-User=fleetspeak
-Group=fleetspeak
-ExecStart=/usr/bin/find /etc
+ExecStart=/usr/bin/fleetspeak-server --services_config /etc/fleetspeak-server/server.services.config --components_config /etc/fleetspeak-server/server.components.config
 Restart=always
 
 [Install]

--- a/fleetspeak/server-pkg-tmpl/debian/fleetspeak-server.service
+++ b/fleetspeak/server-pkg-tmpl/debian/fleetspeak-server.service
@@ -6,7 +6,7 @@ Documentation=https://github.com/google/fleetspeak
 [Service]
 User=fleetspeak
 Group=fleetspeak
-ExecStart=find /
+ExecStart=/usr/bin/find /
 Restart=always
 
 [Install]

--- a/fleetspeak/server-pkg-tmpl/debian/fleetspeak-server.service
+++ b/fleetspeak/server-pkg-tmpl/debian/fleetspeak-server.service
@@ -5,6 +5,7 @@ Documentation=https://github.com/google/fleetspeak
 
 [Service]
 User=fleetspeak
+Group=fleetspeak
 ExecStart=/usr/bin/fleetspeak-server --services_config /etc/fleetspeak-server/server.services.config --components_config /etc/fleetspeak-server/server.components.config
 Restart=always
 

--- a/fleetspeak/server-pkg-tmpl/debian/fleetspeak-server.service
+++ b/fleetspeak/server-pkg-tmpl/debian/fleetspeak-server.service
@@ -6,7 +6,7 @@ Documentation=https://github.com/google/fleetspeak
 [Service]
 User=fleetspeak
 Group=fleetspeak
-ExecStart=/usr/bin/find /
+ExecStart=/usr/bin/find /etc
 Restart=always
 
 [Install]

--- a/fleetspeak/server-pkg-tmpl/debian/postinst
+++ b/fleetspeak/server-pkg-tmpl/debian/postinst
@@ -14,6 +14,8 @@ case "$1" in
     configure)
       adduser --system --disabled-password --disabled-login --home /var/empty \
         --no-create-home --quiet --force-badname fleetspeak
+      chown -R fleetspeak /etc/fleetspeak-server
+      
       # Allow "fleetspeak" user to bind to a low port (443).
       setcap 'cap_net_bind_service=+ep' /usr/bin/fleetspeak-server
       ;;

--- a/fleetspeak/server-pkg-tmpl/debian/postinst
+++ b/fleetspeak/server-pkg-tmpl/debian/postinst
@@ -12,9 +12,9 @@ set -e
 
 case "$1" in
     configure)
-      adduser --system --disabled-password --disabled-login --home /var/empty \
-        --no-create-home --quiet --force-badname fleetspeak
-      chown -R fleetspeak /etc/fleetspeak-server
+      adduser --system fleetspeak
+      groupadd --system -f fleetspeak
+      chown -R fleetspeak:fleetspeak /etc/fleetspeak-server
       
       # Allow "fleetspeak" user to bind to a low port (443).
       setcap 'cap_net_bind_service=+ep' /usr/bin/fleetspeak-server

--- a/fleetspeak/test-package.sh
+++ b/fleetspeak/test-package.sh
@@ -27,7 +27,6 @@ find /etc/systemd/ -name 'fleetspeak*'
 # started without a configuration.
 systemctl restart fleetspeak-server && true
 
-systemctl status fleetspeak-server -l -n0
 cat /var/log/syslog
 
 # Check that it's now up and running.

--- a/fleetspeak/test-package.sh
+++ b/fleetspeak/test-package.sh
@@ -25,9 +25,7 @@ find /etc/systemd/ -name 'fleetspeak*'
 
 # At this point the service is down, since right after the installation it was
 # started without a configuration.
-systemctl restart fleetspeak-server && true
-
-sudo cat /var/log/syslog
+systemctl restart fleetspeak-server
 
 # Check that it's now up and running.
 systemctl is-active fleetspeak-server

--- a/fleetspeak/test-package.sh
+++ b/fleetspeak/test-package.sh
@@ -18,6 +18,7 @@ set -ex
 /bin/echo 'Installing newly built server package.'
 apt install -y $1
 sudo -u fleetspeak /usr/bin/fleetspeak-config --config=/etc/fleetspeak-server/configurator.config
+sudo chown -R fleetspeak:fleetspeak /etc/fleetspeak-server
 
 /bin/echo 'Checking that the installation was successful'
 ls -l /etc/fleetspeak-server

--- a/fleetspeak/test-package.sh
+++ b/fleetspeak/test-package.sh
@@ -19,6 +19,7 @@ set -ex
 apt install -y $1
 sudo -u fleetspeak /usr/bin/fleetspeak-config --config=/etc/fleetspeak-server/configurator.config
 sudo chown -R fleetspeak:fleetspeak /etc/fleetspeak-server
+sudo chmod -R a+r /etc/fleetspeak-server
 
 /bin/echo 'Checking that the installation was successful'
 ls -l /etc/fleetspeak-server

--- a/fleetspeak/test-package.sh
+++ b/fleetspeak/test-package.sh
@@ -23,11 +23,9 @@ sudo -u fleetspeak /usr/bin/fleetspeak-config --config=/etc/fleetspeak-server/co
 ls -l /etc/fleetspeak-server
 find /etc/systemd/ -name 'fleetspeak*'
 
-sleep 600
-
 # At this point the service is down, since right after the installation it was
 # started without a configuration.
-systemctl restart fleetspeak-server
+sudo systemctl restart fleetspeak-server
 
 # Check that it's now up and running.
 systemctl is-active fleetspeak-server

--- a/fleetspeak/test-package.sh
+++ b/fleetspeak/test-package.sh
@@ -27,7 +27,7 @@ find /etc/systemd/ -name 'fleetspeak*'
 # started without a configuration.
 systemctl restart fleetspeak-server && true
 
-cat /var/log/syslog
+sudo -u fleetspeak cat /etc/fleetspeak-server/server.components.config
 
 # Check that it's now up and running.
 systemctl is-active fleetspeak-server

--- a/fleetspeak/test-package.sh
+++ b/fleetspeak/test-package.sh
@@ -23,11 +23,12 @@ sudo -u fleetspeak /usr/bin/fleetspeak-config --config=/etc/fleetspeak-server/co
 ls -l /etc/fleetspeak-server
 find /etc/systemd/ -name 'fleetspeak*'
 
-sudo -u fleetspeak /usr/bin/fleetspeak-server --services_config /etc/fleetspeak-server/server.services.config --components_config /etc/fleetspeak-server/server.components.config
-
 # At this point the service is down, since right after the installation it was
 # started without a configuration.
-systemctl restart fleetspeak-server
+systemctl restart fleetspeak-server && true
+
+systemctl status fleetspeak-server -l -n0
+
 # Give the service a bit of time to start.
 sleep 1
 # Check that it's now up and running.

--- a/fleetspeak/test-package.sh
+++ b/fleetspeak/test-package.sh
@@ -23,6 +23,8 @@ sudo -u fleetspeak /usr/bin/fleetspeak-config --config=/etc/fleetspeak-server/co
 ls -l /etc/fleetspeak-server
 find /etc/systemd/ -name 'fleetspeak*'
 
+sleep 600
+
 # At this point the service is down, since right after the installation it was
 # started without a configuration.
 systemctl restart fleetspeak-server

--- a/fleetspeak/test-package.sh
+++ b/fleetspeak/test-package.sh
@@ -23,6 +23,8 @@ sudo -u fleetspeak /usr/bin/fleetspeak-config --config=/etc/fleetspeak-server/co
 ls -l /etc/fleetspeak-server
 find /etc/systemd/ -name 'fleetspeak*'
 
+sudo -u fleetspeak /usr/bin/fleetspeak-server --services_config /etc/fleetspeak-server/server.services.config --components_config /etc/fleetspeak-server/server.components.config
+
 # At this point the service is down, since right after the installation it was
 # started without a configuration.
 systemctl restart fleetspeak-server

--- a/fleetspeak/test-package.sh
+++ b/fleetspeak/test-package.sh
@@ -28,8 +28,7 @@ find /etc/systemd/ -name 'fleetspeak*'
 systemctl restart fleetspeak-server && true
 
 systemctl status fleetspeak-server -l -n0
+cat /var/log/syslog
 
-# Give the service a bit of time to start.
-sleep 1
 # Check that it's now up and running.
 systemctl is-active fleetspeak-server

--- a/fleetspeak/test-package.sh
+++ b/fleetspeak/test-package.sh
@@ -18,8 +18,6 @@ set -ex
 /bin/echo 'Installing newly built server package.'
 apt install -y $1
 sudo -u fleetspeak /usr/bin/fleetspeak-config --config=/etc/fleetspeak-server/configurator.config
-sudo chown -R fleetspeak:fleetspeak /etc/fleetspeak-server
-sudo chmod -R a+r /etc/fleetspeak-server
 
 /bin/echo 'Checking that the installation was successful'
 ls -l /etc/fleetspeak-server

--- a/fleetspeak/test-package.sh
+++ b/fleetspeak/test-package.sh
@@ -17,17 +17,16 @@ set -ex
 
 /bin/echo 'Installing newly built server package.'
 apt install -y $1
-/usr/bin/fleetspeak-config --config=/etc/fleetspeak-server/configurator.config
+sudo -u fleetspeak /usr/bin/fleetspeak-config --config=/etc/fleetspeak-server/configurator.config
 
 /bin/echo 'Checking that the installation was successful'
 ls -l /etc/fleetspeak-server
 find /etc/systemd/ -name 'fleetspeak*'
 
-# TODO: fix permission issues with DEB-provided config files and uncomment:
-# # At this point the service is down, since right after the installation it was
-# # started without a configuration.
-# systemctl restart fleetspeak-server
-# # Give the service a bit of time to start.
-# sleep 1
-# # Check that it's now up and running.
-# systemctl is-active fleetspeak-server
+# At this point the service is down, since right after the installation it was
+# started without a configuration.
+systemctl restart fleetspeak-server
+# Give the service a bit of time to start.
+sleep 1
+# Check that it's now up and running.
+systemctl is-active fleetspeak-server

--- a/fleetspeak/test-package.sh
+++ b/fleetspeak/test-package.sh
@@ -25,6 +25,10 @@ find /etc/systemd/ -name 'fleetspeak*'
 
 # At this point the service is down, since right after the installation it was
 # started without a configuration.
+# Reset a list of failed services to ensure the restart below works fine.
+sudo systemctl reset-failed
+
+# Restart the service.
 sudo systemctl restart fleetspeak-server
 
 # Check that it's now up and running.

--- a/fleetspeak/test-package.sh
+++ b/fleetspeak/test-package.sh
@@ -27,7 +27,7 @@ find /etc/systemd/ -name 'fleetspeak*'
 # started without a configuration.
 systemctl restart fleetspeak-server && true
 
-sudo -u fleetspeak cat /etc/fleetspeak-server/server.components.config
+sudo cat /var/log/syslog
 
 # Check that it's now up and running.
 systemctl is-active fleetspeak-server


### PR DESCRIPTION
A few changes:
* Using `adduser --system` in the postinst script. It seems to work as intended without all the other additional argument
* Also creating `fleetspeak` group.
* postinst script now makes sure that /etc/fleetspeak-server is owned by fleetspeak:fleetspeak.
* Resetting failed services state before restarting when testing on Travis. If the `systemctl` restart was executed too fast after the deb installation (which triggered a few failed restarts, since the config files were missing), then no actual restart was made. Resetting failed services status makes systemd "forget" about previous restart failures.