### PR TITLE
Running Fleetspeak Debian client with KillMode=process.

### DIFF
--- a/fleetspeak/client-pkg-tmpl/debian/fleetspeak-client.service
+++ b/fleetspeak/client-pkg-tmpl/debian/fleetspeak-client.service
@@ -7,6 +7,7 @@ Documentation=https://github.com/google/fleetspeak
 User=root
 ExecStart=/usr/bin/fleetspeak-client --config /etc/fleetspeak-client/client.config
 Restart=always
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This way GRR can properly restart Fleetspeak daemon on self-update, without the risk of getting killed itself.