### PR TITLE
Protecting against a race in client_test.go

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,7 +45,7 @@ test_script:
 - C:\fsenv\Scripts\activate.bat
 - python --version
 - pip show fleetspeak
-- go test github.com/google/fleetspeak/fleetspeak/src/common/... --timeout 180s
-- go test github.com/google/fleetspeak/fleetspeak/src/client/... --timeout 180s
+- go test -race github.com/google/fleetspeak/fleetspeak/src/common/... --timeout 180s
+- go test -race github.com/google/fleetspeak/fleetspeak/src/client/... --timeout 180s
 # TODO(ogaro): Move src/windows to src/client.
-- go test github.com/google/fleetspeak/fleetspeak/src/windows/... --timeout 180s
+- go test -race github.com/google/fleetspeak/fleetspeak/src/windows/... --timeout 180s

--- a/fleetspeak/test.sh
+++ b/fleetspeak/test.sh
@@ -63,7 +63,7 @@ time (
   RC=0
 
   pretty_echo 'Executing Go tests.'
-  time go test --timeout 2m ${TEST_GO_DIRS} || RC=1
+  time go test -race --timeout 2m ${TEST_GO_DIRS} || RC=1
 
   pretty_echo 'Executing Python tests.'
   python -m unittest discover --pattern '*_test.py' || RC=2


### PR DESCRIPTION
Turned "-race" for CI "go test" invocations.