### PR TITLE
Fix some staticcheck warnings in src/client/https.

### DIFF
--- a/fleetspeak/src/client/https/polling.go
+++ b/fleetspeak/src/client/https/polling.go
@@ -242,7 +242,7 @@ func (c *Communicator) processingLoop() {
 				poll()
 			}
 			return
-		case _ = <-t.C:
+		case <-t.C:
 			poll()
 		case m := <-c.cctx.Outbox():
 			t.Stop()

--- a/fleetspeak/src/client/https/polling_test.go
+++ b/fleetspeak/src/client/https/polling_test.go
@@ -437,7 +437,7 @@ func (hp *httpsProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log.Infof("Got proxy request: %s.", string(d))
 
 	if r.Method != http.MethodConnect {
-		returnError(fmt.Errorf("Proxy received invalid method: %s.", r.Method))
+		returnError(fmt.Errorf("Proxy received invalid method: %s", r.Method))
 		return
 	}
 	conn, err := net.Dial("tcp", r.Host)

--- a/fleetspeak/src/client/https/streaming_test.go
+++ b/fleetspeak/src/client/https/streaming_test.go
@@ -367,12 +367,10 @@ func TestStreamingCommunicator(t *testing.T) {
 	var granted uint64
 F:
 	for {
-		select {
-		case rcb := <-received:
-			granted += rcb.AllowedMessages["NOOPService"]
-			if granted >= 32 {
-				break F
-			}
+		rcb := <-received
+		granted += rcb.AllowedMessages["NOOPService"]
+		if granted >= 32 {
+			break F
 		}
 	}
 	if granted > 35 {


### PR DESCRIPTION
$ staticcheck github.com/google/fleetspeak/fleetspeak/src/client/https
src/client/https/polling.go:193:33: should use time.Until instead of t.Sub(time.Now()) (S1024)
src/client/https/polling.go:204:83: should use time.Until instead of t.Sub(time.Now()) (S1024)
src/client/https/polling.go:245:8: '_ = <-ch' can be simplified to '<-ch' (S1005)
src/client/https/polling_test.go:461:2: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
src/client/https/polling_test.go:462:2: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
src/client/https/polling_test.go:463:2: '_ = <-ch' can be simplified to '<-ch' (S1005)
src/client/https/polling_test.go:463:5: '_ = <-ch' can be simplified to '<-ch' (S1005)
src/client/https/polling_test.go:514:3: redundant return statement (S1023)
src/client/https/streaming_test.go:369:2: should use for range instead of for { select {} } (S1000)