### PR TITLE
Add possibility to disable the server systemd unit file.

### DIFF
--- a/fleetspeak/server-pkg-tmpl/debian/fleetspeak-server.service
+++ b/fleetspeak/server-pkg-tmpl/debian/fleetspeak-server.service
@@ -2,6 +2,7 @@
 Description=Fleetspeak Server Service
 After=syslog.target network.target
 Documentation=https://github.com/google/fleetspeak
+ConditionPathExists=!/etc/fleetspeak-server/disabled
 
 [Service]
 User=fleetspeak


### PR DESCRIPTION
The unit file is disabled/enabled by creating/removing the file
/etc/fleetspeak-server/disabled.

We use the file "disabled" (and not "enabled" as expected) since the default
behaviour (corresponding to the file missing) should be enabled.