### PR TITLE
Ensure service setup failure message always includes service name

### DIFF
--- a/fleetspeak/src/client/client.go
+++ b/fleetspeak/src/client/client.go
@@ -179,7 +179,7 @@ func New(cfg config.Configuration, cmps Components) (*Client, error) {
 	} else {
 		for _, s := range ss {
 			if err := ret.sc.InstallService(s, nil); err != nil {
-				log.Warningf("Unable to install service, ignoring: %v", err)
+				log.Warningf("Unable to install service [%s], ignoring: %v", s.Name, err)
 			}
 		}
 	}

--- a/fleetspeak/src/client/services.go
+++ b/fleetspeak/src/client/services.go
@@ -85,11 +85,14 @@ ll:
 					continue ll
 				}
 			}
-			return fmt.Errorf("service config requires label %v", l)
+			return fmt.Errorf("service config [%s] requires label %v", cfg.Name, l)
 		}
 	}
 
-	return c.InstallService(&cfg, sd.Signature)
+	if err := c.InstallService(&cfg, sd.Signature); err != nil {
+		return fmt.Errorf("installing [%s]: %w", cfg.Name, err)
+	}
+	return nil
 }
 
 func validateServiceName(sname string) error {


### PR DESCRIPTION
This is essential for diagnosing system-level issues.