### PR TITLE
Improve visibility of Windows socketservice setup errors

### DIFF
--- a/fleetspeak/src/client/socketservice/checks/sock_checks_windows.go
+++ b/fleetspeak/src/client/socketservice/checks/sock_checks_windows.go
@@ -18,7 +18,6 @@ package checks
 
 import (
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -125,7 +124,7 @@ func checkOwnership(filepath string) error {
 	// gets assigned; it's not clear whether we actually want to do this.
 
 	if fg != cg {
-		return errors.New("unexpected group SID")
+		return fmt.Errorf("unexpected group SID (got %v want %v)", fg, cg)
 	}
 
 	return nil

--- a/fleetspeak/src/client/socketservice/socketservice_windows.go
+++ b/fleetspeak/src/client/socketservice/socketservice_windows.go
@@ -22,6 +22,8 @@ import (
 	"os"
 	"path/filepath"
 
+	log "github.com/golang/glog"
+
 	"github.com/google/fleetspeak/fleetspeak/src/client/socketservice/checks"
 	"github.com/google/fleetspeak/fleetspeak/src/windows/wnixsocket"
 	"github.com/hectane/go-acl"
@@ -32,10 +34,12 @@ func listen(socketPath string) (net.Listener, error) {
 
 	// Ensure that the parent directory exists. wnixsocket.Listen ensures the
 	// socket file exists and is truncated.
-	if _, err := os.Lstat(parent); err != nil {
-		if !os.IsNotExist(err) {
-			return nil, fmt.Errorf("os.Lstat failed: %v", err)
-		}
+	stat, err := os.Lstat(parent)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("os.Lstat failed: %v", err)
+	}
+	if err == nil {
+		log.Infof("wnix socket parent %v already exists (IsDir: %v)", parent, stat.Mode().IsDir())
 	}
 
 	if err := os.MkdirAll(parent, 0); err != nil {


### PR DESCRIPTION
 - Report the SIDs that are causing is to bail on service setup
 - Log whether the socket's parent directory already existed