### PR TITLE
New label for MessageSaved metric: isProcessed

### DIFF
--- a/fleetspeak/src/inttesting/integrationtest/frr.go
+++ b/fleetspeak/src/inttesting/integrationtest/frr.go
@@ -69,7 +69,7 @@ func (c *statsCounter) MessageIngested(backlogged bool, m *fspb.Message) {
 	}
 }
 
-func (c *statsCounter) MessageSaved(service, messageType string, forClient bool, savedPayloadBytes int) {
+func (c *statsCounter) MessageSaved(service, messageType string, forClient bool, savedPayloadBytes int, isProcessed bool) {
 	if service == "FRR" {
 		atomic.AddInt64(&c.payloadBytesSaved, int64(savedPayloadBytes))
 	}

--- a/fleetspeak/src/server/internal/services/manager.go
+++ b/fleetspeak/src/server/internal/services/manager.go
@@ -275,7 +275,7 @@ func (c *Manager) HandleNewMessages(ctx context.Context, msgs []*fspb.Message, c
 		if m.Data != nil {
 			s = len(m.Data.TypeUrl) + len(m.Data.Value)
 		}
-		c.stats.MessageSaved(m.Destination.ServiceName, m.MessageType, false, s)
+		c.stats.MessageSaved(m.Destination.ServiceName, m.MessageType, false, s, m.Data == nil)
 	}
 	ctx2, fin2 := context.WithTimeout(ctx, 30*time.Second)
 	defer fin2()

--- a/fleetspeak/src/server/stats.go
+++ b/fleetspeak/src/server/stats.go
@@ -38,7 +38,7 @@ type noopStatsCollector struct{}
 func (s noopStatsCollector) MessageIngested(backlogged bool, m *fspb.Message) {
 }
 
-func (s noopStatsCollector) MessageSaved(service, messageType string, forClient bool, savedPayloadBytes int) {
+func (s noopStatsCollector) MessageSaved(service, messageType string, forClient bool, savedPayloadBytes int, isProcessed bool) {
 }
 
 func (s noopStatsCollector) MessageProcessed(start, end time.Time, service, messageType string) {
@@ -150,7 +150,7 @@ func (s PrometheusStatsCollector) MessageIngested(backlogged bool, m *fspb.Messa
 	}
 }
 
-func (s PrometheusStatsCollector) MessageSaved(service, messageType string, forClient bool, savedPayloadBytes int) {
+func (s PrometheusStatsCollector) MessageSaved(service, messageType string, forClient bool, savedPayloadBytes int, isProcessed bool) {
 	messagesSaved.Inc()
 	messagesSavedSize.Add(float64(savedPayloadBytes))
 }

--- a/fleetspeak/src/server/stats/collector.go
+++ b/fleetspeak/src/server/stats/collector.go
@@ -91,7 +91,7 @@ type Collector interface {
 	MessageIngested(backlogged bool, m *fspb.Message)
 
 	// MessageSaved is called when a message is first saved to the database.
-	MessageSaved(service, messageType string, forClient bool, savedPayloadBytes int)
+	MessageSaved(service, messageType string, forClient bool, savedPayloadBytes int, isProcessed bool)
 
 	// MessageProcessed is called when a message is successfully processed by the
 	// server.


### PR DESCRIPTION
In the method [HandleNewMessages](https://github.com/google/fleetspeak/blob/8429654c850843511bc3d11c11e6e4f31067bdff/fleetspeak/src/server/internal/services/manager.go#L232) of [Manager](https://github.com/google/fleetspeak/blob/8429654c850843511bc3d11c11e6e4f31067bdff/fleetspeak/src/server/internal/services/manager.go#L44), the data of messages that are processed [is set to `nil`](https://github.com/google/fleetspeak/blob/8429654c850843511bc3d11c11e6e4f31067bdff/fleetspeak/src/server/internal/services/manager.go#L261). Then, the payload bytes of processed messages is effectively set to 0 bytes. When this is [recorded](https://github.com/google/fleetspeak/blob/8429654c850843511bc3d11c11e6e4f31067bdff/fleetspeak/src/server/internal/services/manager.go#L278) with the stats collector defined, there is no good way to distinguish between messages that were processed and messages that weren't.

Later on, we would want to graph this data and be able to differentiate between the two. Therefore, I suggest adding a new boolean label, `isProcessed`, to the metric [MessageSaved](https://github.com/google/fleetspeak/blob/8429654c850843511bc3d11c11e6e4f31067bdff/fleetspeak/src/server/stats/collector.go#L94).

Some things to note with this change:
- When messages that are fully processed will be saved, their corresponding payload bytes will be 0. At first look, that can look nonsense; but when we expose the stats (to [Prometheus](https://github.com/google/fleetspeak/blob/8429654c850843511bc3d11c11e6e4f31067bdff/fleetspeak/src/server/stats.go#L153), for example), we can choose not to export the payload bytes of processed messages by utilizing this new label, and thus avoid unnecessary overhead.
- When messages that were *not* fully processed will be saved, it will be some non-negative value. This can be meaningful, and can be exported to dashboards.
- This change **will break** #258. Therefore, once #258 is merged, I will make sure to safely merge it in this PR, and then mark this PR as ready for review.
- ~~I couldn't manage to stress-test Fleetspeak enough to get messages that are processed and messages that are not processed in the same deployment (only separately). I tried changing the [timeout value](https://github.com/google/fleetspeak/blob/8429654c850843511bc3d11c11e6e4f31067bdff/fleetspeak/src/server/internal/services/manager.go#L243) to 1, where all messages are fully processed in my case, and to 0, where all messages are not processed; if someone has some tips on testing this, I'd appreciate it.~~ Apparently some messages of type `ResourceUsage` can go through with 0 timeout value. So I managed to get both processed and not processed messages in the same deployment.