### PR TITLE
Refactor e2e testing framework to test multiple clients and servers

### DIFF
--- a/fleetspeak/src/e2etesting/e2etest.sh
+++ b/fleetspeak/src/e2etesting/e2etest.sh
@@ -3,4 +3,4 @@ cd $(dirname $0)/../../../
 python3 -m venv /tmp/.venv/FLEETSPEAK
 /tmp/.venv/FLEETSPEAK/bin/pip install absl-py protobuf fleetspeak > /dev/null
 source /tmp/.venv/FLEETSPEAK/bin/activate
-go run fleetspeak/src/e2etesting/run_end_to_end_tests.go --mysql_database=fleetspeak_test --mysql_username=fsuser --mysql_password=fsuserPass1!
+go run fleetspeak/src/e2etesting/run_end_to_end_tests.go --mysql_database=fleetspeak_test --mysql_username=fsuser --mysql_password=fsuserPass1! --num_clients=10 --num_servers=2

--- a/fleetspeak/src/e2etesting/lib/setup_components.go
+++ b/fleetspeak/src/e2etesting/lib/setup_components.go
@@ -104,9 +104,10 @@ func getNewClientIDs(admin servicesPb.AdminClient, startTime time.Time) ([]strin
 		}
 		if lastContactTime.After(startTime) {
 			id, err := common.BytesToClientID(cl.ClientId)
-			if err == nil {
-				newClients = append(newClients, fmt.Sprintf("%v", id))
+			if err != nil {
+				return nil, fmt.Errorf("Invalid clientID: %v", err)
 			}
+			newClients = append(newClients, fmt.Sprintf("%v", id))
 		}
 	}
 	return newClients, nil

--- a/fleetspeak/src/e2etesting/run_end_to_end_tests.go
+++ b/fleetspeak/src/e2etesting/run_end_to_end_tests.go
@@ -6,30 +6,21 @@ import (
 	"github.com/google/fleetspeak/fleetspeak/src/e2etesting/lib"
 	"github.com/google/fleetspeak/fleetspeak/src/e2etesting/tests"
 	"os"
-	"strconv"
 )
 
 var (
 	mysqlDatabase = flag.String("mysql_database", "", "MySQL database name to use")
 	mysqlUsername = flag.String("mysql_username", "", "MySQL username to use")
 	mysqlPassword = flag.String("mysql_password", "", "MySQL password to use")
-	numClientsStr = flag.String("num_clients", "1", "Number of clients to test")
-	numServersStr = flag.String("num_servers", "1", "Number of servers to test")
+	numClients    = flag.Int("num_clients", 1, "Number of clients to test")
+	numServers    = flag.Int("num_servers", 1, "Number of servers to test")
 )
 
 func run() error {
 	msPort := 6059
-	numClients, err := strconv.Atoi(*numClientsStr)
-	if err != nil {
-		return fmt.Errorf("Unable to parse num_clients flag. Should be integer, got: %v", *numClientsStr)
-	}
-	numServers, err := strconv.Atoi(*numServersStr)
-	if err != nil {
-		return fmt.Errorf("Unable to parse num_servers flag. Should be integer, got: %v", *numServersStr)
-	}
 
 	var componentsInfo setup.ComponentsInfo
-	err = componentsInfo.ConfigureAndStart(setup.MysqlCredentials{Password: *mysqlPassword, Username: *mysqlUsername, Database: *mysqlDatabase}, msPort, numServers, numClients)
+	err := componentsInfo.ConfigureAndStart(setup.MysqlCredentials{Password: *mysqlPassword, Username: *mysqlUsername, Database: *mysqlDatabase}, msPort, *numServers, *numClients)
 	defer componentsInfo.KillAll()
 	if err != nil {
 		return fmt.Errorf("Failed to start components: %v", err)

--- a/fleetspeak/src/e2etesting/tests/end_to_end_tests.go
+++ b/fleetspeak/src/e2etesting/tests/end_to_end_tests.go
@@ -2,7 +2,6 @@ package endtoendtests
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	fgrpc "github.com/google/fleetspeak/fleetspeak/src/inttesting/frr/proto/fleetspeak_frr"
 	"google.golang.org/grpc"
@@ -10,8 +9,8 @@ import (
 	"time"
 )
 
-// RunTest creates a hunt for 1 FS client and checks that the client responds
-func RunTest(msPort int, clientID string) error {
+// RunTest creates a hunt for FS clients and checks that all of them respond
+func RunTest(msPort int, clientIDs []string) error {
 	conn, err := grpc.Dial(fmt.Sprintf("localhost:%v", msPort), grpc.WithInsecure(), grpc.WithBlock())
 	defer conn.Close()
 	if err != nil {
@@ -21,37 +20,47 @@ func RunTest(msPort int, clientID string) error {
 	client := fgrpc.NewMasterClient(conn)
 	ctx := context.Background()
 
-	endTime := time.Now().Add(time.Second * 10)
+	rand.Seed(int64(time.Now().Nanosecond()))
 	requestID := rand.Int63()
 
-	_, err = client.CreateHunt(ctx, &fgrpc.CreateHuntRequest{Limit: 1, Data: &fgrpc.TrafficRequestData{
+	_, err = client.CreateHunt(ctx, &fgrpc.CreateHuntRequest{Limit: uint64(len(clientIDs)), Data: &fgrpc.TrafficRequestData{
 		MasterId:       0,
 		RequestId:      requestID,
 		NumMessages:    1,
 		MessageSize:    1,
-		MessageDelayMs: 1000,
+		MessageDelayMs: 0,
 	}})
+
 	if err != nil {
 		return fmt.Errorf("Unable to create hunt: %v", err)
 	}
 
-	for {
-		response, err := client.CompletedRequests(ctx, &fgrpc.CompletedRequestsRequest{ClientId: clientID})
-		if err != nil {
-			return fmt.Errorf("Failed to get completed requests: %v", err)
-		}
-		if len(response.RequestIds) == 1 {
-			if response.RequestIds[0] != requestID {
-				return fmt.Errorf("Invalid request id (expected: %v, received: %v)", requestID, response.RequestIds[0])
+	respondedClients := make(map[string]bool)
+	for _, clientID := range clientIDs {
+		respondedClients[clientID] = false
+	}
+
+	for i := 0; i < 30; i++ {
+		for clientID, responded := range respondedClients {
+			if responded {
+				continue
 			}
+			response, err := client.CompletedRequests(ctx, &fgrpc.CompletedRequestsRequest{ClientId: clientID})
+			if err != nil {
+				continue
+			}
+			for _, reqID := range response.RequestIds {
+				if reqID == requestID {
+					delete(respondedClients, clientID)
+					break
+				}
+			}
+		}
+
+		if len(respondedClients) == 0 {
 			return nil
 		}
-		if len(response.RequestIds) != 0 {
-			return fmt.Errorf("Invalid length of response. Expected 0 or 1, got: %v", len(response.RequestIds))
-		}
-		if time.Now().After(endTime) {
-			break
-		}
+		time.Sleep(time.Second)
 	}
-	return errors.New("Not all responses were received")
+	return fmt.Errorf("Received responses from %v clients out of %v", len(clientIDs)-len(respondedClients), len(clientIDs))
 }

--- a/fleetspeak/src/e2etesting/tests/end_to_end_tests.go
+++ b/fleetspeak/src/e2etesting/tests/end_to_end_tests.go
@@ -36,13 +36,10 @@ func RunTest(msPort int, clientIDs []string) error {
 	}
 
 	respondedClients := make(map[string]bool)
-	for _, clientID := range clientIDs {
-		respondedClients[clientID] = false
-	}
 
 	for i := 0; i < 30; i++ {
-		for clientID, responded := range respondedClients {
-			if responded {
+		for _, clientID := range clientIDs {
+			if _, ok := respondedClients[clientID]; ok {
 				continue
 			}
 			response, err := client.CompletedRequests(ctx, &fgrpc.CompletedRequestsRequest{ClientId: clientID})
@@ -51,13 +48,13 @@ func RunTest(msPort int, clientIDs []string) error {
 			}
 			for _, reqID := range response.RequestIds {
 				if reqID == requestID {
-					delete(respondedClients, clientID)
+					respondedClients[clientID] = true
 					break
 				}
 			}
 		}
 
-		if len(respondedClients) == 0 {
+		if len(respondedClients) == len(clientIDs) {
 			return nil
 		}
 		time.Sleep(time.Second)


### PR DESCRIPTION
Now it's possible to specify the number of FS clients and servers to test. These numbers are passed as flags in e2etest.sh. The only test creates a broadcast request and waits for responses from all the clients. Clients are evenly distributed between servers. The type of connection was changed from polling to streaming.