### PR TITLE
Modify Collector interface methods

### DIFF
--- a/fleetspeak/src/inttesting/integrationtest/frr.go
+++ b/fleetspeak/src/inttesting/integrationtest/frr.go
@@ -91,7 +91,7 @@ func (c *statsCounter) MessageErrored(start, end time.Time, service string, isTe
 	}
 }
 
-func (c *statsCounter) MessageDropped(service string, m *fspb.Message) {
+func (c *statsCounter) MessageDropped(m *fspb.Message) {
 	if service == "FRR" {
 		atomic.AddInt64(&c.messagesDropped, 1)
 	}

--- a/fleetspeak/src/inttesting/integrationtest/frr.go
+++ b/fleetspeak/src/inttesting/integrationtest/frr.go
@@ -91,7 +91,7 @@ func (c *statsCounter) MessageErrored(start, end time.Time, service string, isTe
 	}
 }
 
-func (c *statsCounter) MessageDropped(service, messageType string) {
+func (c *statsCounter) MessageDropped(service string, m *fspb.Message) {
 	if service == "FRR" {
 		atomic.AddInt64(&c.messagesDropped, 1)
 	}

--- a/fleetspeak/src/inttesting/integrationtest/frr.go
+++ b/fleetspeak/src/inttesting/integrationtest/frr.go
@@ -69,8 +69,12 @@ func (c *statsCounter) MessageIngested(backlogged bool, m *fspb.Message) {
 	}
 }
 
-func (c *statsCounter) MessageSaved(service, messageType string, forClient bool, savedPayloadBytes int) {
+func (c *statsCounter) MessageSaved(forClient bool, m *fspb.Message) {
 	if service == "FRR" {
+		savedPayloadBytes := 0
+		if m.Data != nil {
+			savedPayloadBytes = len(m.Data.TypeUrl) + len(m.Data.Value)
+		}
 		atomic.AddInt64(&c.payloadBytesSaved, int64(savedPayloadBytes))
 	}
 }

--- a/fleetspeak/src/inttesting/integrationtest/frr.go
+++ b/fleetspeak/src/inttesting/integrationtest/frr.go
@@ -70,7 +70,7 @@ func (c *statsCounter) MessageIngested(backlogged bool, m *fspb.Message) {
 }
 
 func (c *statsCounter) MessageSaved(forClient bool, m *fspb.Message) {
-	if service == "FRR" {
+	if m.Destination.ServiceName == "FRR" {
 		savedPayloadBytes := 0
 		if m.Data != nil {
 			savedPayloadBytes = len(m.Data.TypeUrl) + len(m.Data.Value)
@@ -80,19 +80,19 @@ func (c *statsCounter) MessageSaved(forClient bool, m *fspb.Message) {
 }
 
 func (c *statsCounter) MessageProcessed(start, end time.Time, m *fspb.Message) {
-	if service == "FRR" {
+	if m.Destination.ServiceName == "FRR" {
 		atomic.AddInt64(&c.messagesProcessed, 1)
 	}
 }
 
 func (c *statsCounter) MessageErrored(start, end time.Time, isTemp bool, m *fspb.Message) {
-	if service == "FRR" {
+	if m.Destination.ServiceName == "FRR" {
 		atomic.AddInt64(&c.messagesErrored, 1)
 	}
 }
 
 func (c *statsCounter) MessageDropped(m *fspb.Message) {
-	if service == "FRR" {
+	if m.Destination.ServiceName == "FRR" {
 		atomic.AddInt64(&c.messagesDropped, 1)
 	}
 }

--- a/fleetspeak/src/inttesting/integrationtest/frr.go
+++ b/fleetspeak/src/inttesting/integrationtest/frr.go
@@ -79,7 +79,7 @@ func (c *statsCounter) MessageSaved(forClient bool, m *fspb.Message) {
 	}
 }
 
-func (c *statsCounter) MessageProcessed(start, end time.Time, service, messageType string) {
+func (c *statsCounter) MessageProcessed(start, end time.Time, service string, m *fspb.Message) {
 	if service == "FRR" {
 		atomic.AddInt64(&c.messagesProcessed, 1)
 	}

--- a/fleetspeak/src/inttesting/integrationtest/frr.go
+++ b/fleetspeak/src/inttesting/integrationtest/frr.go
@@ -85,7 +85,7 @@ func (c *statsCounter) MessageProcessed(start, end time.Time, service string, m 
 	}
 }
 
-func (c *statsCounter) MessageErrored(start, end time.Time, service, messageType string, isTemp bool) {
+func (c *statsCounter) MessageErrored(start, end time.Time, service string, isTemp bool, m *fspb.Message) {
 	if service == "FRR" {
 		atomic.AddInt64(&c.messagesErrored, 1)
 	}

--- a/fleetspeak/src/inttesting/integrationtest/frr.go
+++ b/fleetspeak/src/inttesting/integrationtest/frr.go
@@ -79,7 +79,7 @@ func (c *statsCounter) MessageSaved(forClient bool, m *fspb.Message) {
 	}
 }
 
-func (c *statsCounter) MessageProcessed(start, end time.Time, service string, m *fspb.Message) {
+func (c *statsCounter) MessageProcessed(start, end time.Time, m *fspb.Message) {
 	if service == "FRR" {
 		atomic.AddInt64(&c.messagesProcessed, 1)
 	}

--- a/fleetspeak/src/inttesting/integrationtest/frr.go
+++ b/fleetspeak/src/inttesting/integrationtest/frr.go
@@ -85,7 +85,7 @@ func (c *statsCounter) MessageProcessed(start, end time.Time, m *fspb.Message) {
 	}
 }
 
-func (c *statsCounter) MessageErrored(start, end time.Time, service string, isTemp bool, m *fspb.Message) {
+func (c *statsCounter) MessageErrored(start, end time.Time, isTemp bool, m *fspb.Message) {
 	if service == "FRR" {
 		atomic.AddInt64(&c.messagesErrored, 1)
 	}

--- a/fleetspeak/src/server/components/prometheus/prometheus.go
+++ b/fleetspeak/src/server/components/prometheus/prometheus.go
@@ -215,7 +215,7 @@ func (s StatsCollector) MessageProcessed(start, end time.Time, m *fspb.Message) 
 	messagesProcessed.WithLabelValues(m.MessageType, m.Destination.ServiceName).Observe(end.Sub(start).Seconds())
 }
 
-func (s StatsCollector) MessageErrored(start, end time.Time, service string, isTemp bool, m *fspb.Message) {
+func (s StatsCollector) MessageErrored(start, end time.Time, isTemp bool, m *fspb.Message) {
 	messagesErrored.WithLabelValues(m.MessageType, strconv.FormatBool(isTemp)).Observe(end.Sub(start).Seconds())
 }
 

--- a/fleetspeak/src/server/components/prometheus/prometheus.go
+++ b/fleetspeak/src/server/components/prometheus/prometheus.go
@@ -193,11 +193,11 @@ type StatsCollector struct{}
 
 func (s StatsCollector) MessageIngested(backlogged bool, m *fspb.Message) {
 	messagesIngested.WithLabelValues(strconv.FormatBool(backlogged), m.Source.ServiceName, m.Destination.ServiceName, m.MessageType).Inc()
-	payloadBytes := calculateIngestedPayloadBytes(m)
+	payloadBytes := calculatePayloadBytes(m)
 	messagesIngestedSize.WithLabelValues(strconv.FormatBool(backlogged), m.Source.ServiceName, m.Destination.ServiceName, m.MessageType).Add(float64(payloadBytes))
 }
 
-func calculateIngestedPayloadBytes(m *fspb.Message) int {
+func calculatePayloadBytes(m *fspb.Message) int {
 	payloadBytes := 0
 	if m.Data != nil {
 		payloadBytes = len(m.Data.TypeUrl) + len(m.Data.Value)

--- a/fleetspeak/src/server/components/prometheus/prometheus.go
+++ b/fleetspeak/src/server/components/prometheus/prometheus.go
@@ -219,8 +219,8 @@ func (s StatsCollector) MessageErrored(start, end time.Time, service string, isT
 	messagesErrored.WithLabelValues(m.MessageType, strconv.FormatBool(isTemp)).Observe(end.Sub(start).Seconds())
 }
 
-func (s StatsCollector) MessageDropped(service, messageType string) {
-	messagesDropped.WithLabelValues(service, messageType).Inc()
+func (s StatsCollector) MessageDropped(service string, m *fspb.Message) {
+	messagesDropped.WithLabelValues(service, m.MessageType).Inc()
 }
 
 func (s StatsCollector) ClientPoll(info stats.PollInfo) {

--- a/fleetspeak/src/server/components/prometheus/prometheus.go
+++ b/fleetspeak/src/server/components/prometheus/prometheus.go
@@ -211,8 +211,8 @@ func (s StatsCollector) MessageSaved(forClient bool, m *fspb.Message) {
 	messagesSavedSize.WithLabelValues(m.Destination.ServiceName, m.MessageType, strconv.FormatBool(forClient)).Add(float64(savedPayloadBytes))
 }
 
-func (s StatsCollector) MessageProcessed(start, end time.Time, service, messageType string) {
-	messagesProcessed.WithLabelValues(messageType, service).Observe(end.Sub(start).Seconds())
+func (s StatsCollector) MessageProcessed(start, end time.Time, service string, m *fspb.Message) {
+	messagesProcessed.WithLabelValues(m.MessageType, service).Observe(end.Sub(start).Seconds())
 }
 
 func (s StatsCollector) MessageErrored(start, end time.Time, service, messageType string, isTemp bool) {

--- a/fleetspeak/src/server/components/prometheus/prometheus.go
+++ b/fleetspeak/src/server/components/prometheus/prometheus.go
@@ -219,8 +219,8 @@ func (s StatsCollector) MessageErrored(start, end time.Time, service string, isT
 	messagesErrored.WithLabelValues(m.MessageType, strconv.FormatBool(isTemp)).Observe(end.Sub(start).Seconds())
 }
 
-func (s StatsCollector) MessageDropped(service string, m *fspb.Message) {
-	messagesDropped.WithLabelValues(service, m.MessageType).Inc()
+func (s StatsCollector) MessageDropped(m *fspb.Message) {
+	messagesDropped.WithLabelValues(m.Destination.ServiceName, m.MessageType).Inc()
 }
 
 func (s StatsCollector) ClientPoll(info stats.PollInfo) {

--- a/fleetspeak/src/server/components/prometheus/prometheus.go
+++ b/fleetspeak/src/server/components/prometheus/prometheus.go
@@ -211,8 +211,8 @@ func (s StatsCollector) MessageSaved(forClient bool, m *fspb.Message) {
 	messagesSavedSize.WithLabelValues(m.Destination.ServiceName, m.MessageType, strconv.FormatBool(forClient)).Add(float64(savedPayloadBytes))
 }
 
-func (s StatsCollector) MessageProcessed(start, end time.Time, service string, m *fspb.Message) {
-	messagesProcessed.WithLabelValues(m.MessageType, service).Observe(end.Sub(start).Seconds())
+func (s StatsCollector) MessageProcessed(start, end time.Time, m *fspb.Message) {
+	messagesProcessed.WithLabelValues(m.MessageType, m.Destination.ServiceName).Observe(end.Sub(start).Seconds())
 }
 
 func (s StatsCollector) MessageErrored(start, end time.Time, service string, isTemp bool, m *fspb.Message) {

--- a/fleetspeak/src/server/components/prometheus/prometheus.go
+++ b/fleetspeak/src/server/components/prometheus/prometheus.go
@@ -205,9 +205,10 @@ func calculateIngestedPayloadBytes(m *fspb.Message) int {
 	return payloadBytes
 }
 
-func (s StatsCollector) MessageSaved(service, messageType string, forClient bool, savedPayloadBytes int) {
-	messagesSaved.WithLabelValues(service, messageType, strconv.FormatBool(forClient)).Inc()
-	messagesSavedSize.WithLabelValues(service, messageType, strconv.FormatBool(forClient)).Add(float64(savedPayloadBytes))
+func (s StatsCollector) MessageSaved(forClient bool, m *fspb.Message) {
+	messagesSaved.WithLabelValues(m.Destination.ServiceName, m.MessageType, strconv.FormatBool(forClient)).Inc()
+	savedPayloadBytes := calculatePayloadBytes(m)
+	messagesSavedSize.WithLabelValues(m.Destination.ServiceName, m.MessageType, strconv.FormatBool(forClient)).Add(float64(savedPayloadBytes))
 }
 
 func (s StatsCollector) MessageProcessed(start, end time.Time, service, messageType string) {

--- a/fleetspeak/src/server/components/prometheus/prometheus.go
+++ b/fleetspeak/src/server/components/prometheus/prometheus.go
@@ -215,8 +215,8 @@ func (s StatsCollector) MessageProcessed(start, end time.Time, service string, m
 	messagesProcessed.WithLabelValues(m.MessageType, service).Observe(end.Sub(start).Seconds())
 }
 
-func (s StatsCollector) MessageErrored(start, end time.Time, service, messageType string, isTemp bool) {
-	messagesErrored.WithLabelValues(messageType, strconv.FormatBool(isTemp)).Observe(end.Sub(start).Seconds())
+func (s StatsCollector) MessageErrored(start, end time.Time, service string, isTemp bool, m *fspb.Message) {
+	messagesErrored.WithLabelValues(m.MessageType, strconv.FormatBool(isTemp)).Observe(end.Sub(start).Seconds())
 }
 
 func (s StatsCollector) MessageDropped(service, messageType string) {

--- a/fleetspeak/src/server/internal/services/manager.go
+++ b/fleetspeak/src/server/internal/services/manager.go
@@ -188,7 +188,7 @@ func (s *liveService) processMessage(ctx context.Context, m *fspb.Message) *fspb
 		if s.pLogLimiter.Allow() {
 			log.Warningf("%s: Overloaded with %d concurrent messages, dropping excess, will retry.", s.name, s.maxParallelism)
 		}
-		s.manager.stats.MessageDropped(s.name, m)
+		s.manager.stats.MessageDropped(m)
 		return nil
 	}
 

--- a/fleetspeak/src/server/internal/services/manager.go
+++ b/fleetspeak/src/server/internal/services/manager.go
@@ -268,8 +268,7 @@ func (c *Manager) HandleNewMessages(ctx context.Context, msgs []*fspb.Message, c
 		return ctx.Err()
 	}
 
-	// Record that we are saving messages, data will have been set to nil for
-	// fully processed messages.
+	// Record that we are saving messages.
 	for _, m := range msgs {
 		var s int
 		if m.Data != nil {

--- a/fleetspeak/src/server/internal/services/manager.go
+++ b/fleetspeak/src/server/internal/services/manager.go
@@ -202,7 +202,7 @@ func (s *liveService) processMessage(ctx context.Context, m *fspb.Message) *fspb
 	e := s.service.ProcessMessage(ctx, m)
 	switch {
 	case e == nil:
-		s.manager.stats.MessageProcessed(start, ftime.Now(), s.name, m.MessageType)
+		s.manager.stats.MessageProcessed(start, ftime.Now(), s.name, m)
 		return &fspb.MessageResult{ProcessedTime: db.NowProto()}
 	case service.IsTemporary(e):
 		s.manager.stats.MessageErrored(start, ftime.Now(), s.name, m.MessageType, true)

--- a/fleetspeak/src/server/internal/services/manager.go
+++ b/fleetspeak/src/server/internal/services/manager.go
@@ -188,7 +188,7 @@ func (s *liveService) processMessage(ctx context.Context, m *fspb.Message) *fspb
 		if s.pLogLimiter.Allow() {
 			log.Warningf("%s: Overloaded with %d concurrent messages, dropping excess, will retry.", s.name, s.maxParallelism)
 		}
-		s.manager.stats.MessageDropped(s.name, m.MessageType)
+		s.manager.stats.MessageDropped(s.name, m)
 		return nil
 	}
 

--- a/fleetspeak/src/server/internal/services/manager.go
+++ b/fleetspeak/src/server/internal/services/manager.go
@@ -270,11 +270,7 @@ func (c *Manager) HandleNewMessages(ctx context.Context, msgs []*fspb.Message, c
 
 	// Record that we are saving messages.
 	for _, m := range msgs {
-		var s int
-		if m.Data != nil {
-			s = len(m.Data.TypeUrl) + len(m.Data.Value)
-		}
-		c.stats.MessageSaved(m.Destination.ServiceName, m.MessageType, false, s)
+		c.stats.MessageSaved(false, m)
 	}
 	ctx2, fin2 := context.WithTimeout(ctx, 30*time.Second)
 	defer fin2()

--- a/fleetspeak/src/server/internal/services/manager.go
+++ b/fleetspeak/src/server/internal/services/manager.go
@@ -202,7 +202,7 @@ func (s *liveService) processMessage(ctx context.Context, m *fspb.Message) *fspb
 	e := s.service.ProcessMessage(ctx, m)
 	switch {
 	case e == nil:
-		s.manager.stats.MessageProcessed(start, ftime.Now(), s.name, m)
+		s.manager.stats.MessageProcessed(start, ftime.Now(), m)
 		return &fspb.MessageResult{ProcessedTime: db.NowProto()}
 	case service.IsTemporary(e):
 		s.manager.stats.MessageErrored(start, ftime.Now(), s.name, true, m)

--- a/fleetspeak/src/server/internal/services/manager.go
+++ b/fleetspeak/src/server/internal/services/manager.go
@@ -205,11 +205,11 @@ func (s *liveService) processMessage(ctx context.Context, m *fspb.Message) *fspb
 		s.manager.stats.MessageProcessed(start, ftime.Now(), m)
 		return &fspb.MessageResult{ProcessedTime: db.NowProto()}
 	case service.IsTemporary(e):
-		s.manager.stats.MessageErrored(start, ftime.Now(), s.name, true, m)
+		s.manager.stats.MessageErrored(start, ftime.Now(), true, m)
 		log.Warningf("%s: Temporary error processing message %v, will retry: %v", s.name, mid, e)
 		return nil
 	case !service.IsTemporary(e):
-		s.manager.stats.MessageErrored(start, ftime.Now(), s.name, false, m)
+		s.manager.stats.MessageErrored(start, ftime.Now(), false, m)
 		log.Errorf("%s: Permanent error processing message %v, giving up: %v", s.name, mid, e)
 		failedReason := e.Error()
 		if len(failedReason) > MaxServiceFailureReasonLength {

--- a/fleetspeak/src/server/internal/services/manager.go
+++ b/fleetspeak/src/server/internal/services/manager.go
@@ -205,11 +205,11 @@ func (s *liveService) processMessage(ctx context.Context, m *fspb.Message) *fspb
 		s.manager.stats.MessageProcessed(start, ftime.Now(), s.name, m)
 		return &fspb.MessageResult{ProcessedTime: db.NowProto()}
 	case service.IsTemporary(e):
-		s.manager.stats.MessageErrored(start, ftime.Now(), s.name, m.MessageType, true)
+		s.manager.stats.MessageErrored(start, ftime.Now(), s.name, true, m)
 		log.Warningf("%s: Temporary error processing message %v, will retry: %v", s.name, mid, e)
 		return nil
 	case !service.IsTemporary(e):
-		s.manager.stats.MessageErrored(start, ftime.Now(), s.name, m.MessageType, false)
+		s.manager.stats.MessageErrored(start, ftime.Now(), s.name, false, m)
 		log.Errorf("%s: Permanent error processing message %v, giving up: %v", s.name, mid, e)
 		failedReason := e.Error()
 		if len(failedReason) > MaxServiceFailureReasonLength {

--- a/fleetspeak/src/server/stats.go
+++ b/fleetspeak/src/server/stats.go
@@ -41,7 +41,7 @@ func (s noopStatsCollector) MessageSaved(forClient bool, m *fspb.Message) {
 func (s noopStatsCollector) MessageProcessed(start, end time.Time, service string, m *fspb.Message) {
 }
 
-func (s noopStatsCollector) MessageErrored(start, end time.Time, service, messageType string, isTemp bool) {
+func (s noopStatsCollector) MessageErrored(start, end time.Time, service string, isTemp bool, m *fspb.Message) {
 }
 
 func (s noopStatsCollector) MessageDropped(service, messageType string) {

--- a/fleetspeak/src/server/stats.go
+++ b/fleetspeak/src/server/stats.go
@@ -44,7 +44,7 @@ func (s noopStatsCollector) MessageProcessed(start, end time.Time, m *fspb.Messa
 func (s noopStatsCollector) MessageErrored(start, end time.Time, service string, isTemp bool, m *fspb.Message) {
 }
 
-func (s noopStatsCollector) MessageDropped(service string, m *fspb.Message) {
+func (s noopStatsCollector) MessageDropped(m *fspb.Message) {
 }
 
 func (s noopStatsCollector) ClientPoll(info stats.PollInfo) {

--- a/fleetspeak/src/server/stats.go
+++ b/fleetspeak/src/server/stats.go
@@ -44,7 +44,7 @@ func (s noopStatsCollector) MessageProcessed(start, end time.Time, service strin
 func (s noopStatsCollector) MessageErrored(start, end time.Time, service string, isTemp bool, m *fspb.Message) {
 }
 
-func (s noopStatsCollector) MessageDropped(service, messageType string) {
+func (s noopStatsCollector) MessageDropped(service string, m *fspb.Message) {
 }
 
 func (s noopStatsCollector) ClientPoll(info stats.PollInfo) {

--- a/fleetspeak/src/server/stats.go
+++ b/fleetspeak/src/server/stats.go
@@ -38,7 +38,7 @@ func (s noopStatsCollector) MessageIngested(backlogged bool, m *fspb.Message) {
 func (s noopStatsCollector) MessageSaved(forClient bool, m *fspb.Message) {
 }
 
-func (s noopStatsCollector) MessageProcessed(start, end time.Time, service string, m *fspb.Message) {
+func (s noopStatsCollector) MessageProcessed(start, end time.Time, m *fspb.Message) {
 }
 
 func (s noopStatsCollector) MessageErrored(start, end time.Time, service string, isTemp bool, m *fspb.Message) {

--- a/fleetspeak/src/server/stats.go
+++ b/fleetspeak/src/server/stats.go
@@ -35,7 +35,7 @@ type noopStatsCollector struct{}
 func (s noopStatsCollector) MessageIngested(backlogged bool, m *fspb.Message) {
 }
 
-func (s noopStatsCollector) MessageSaved(service, messageType string, forClient bool, savedPayloadBytes int) {
+func (s noopStatsCollector) MessageSaved(forClient bool, m *fspb.Message) {
 }
 
 func (s noopStatsCollector) MessageProcessed(start, end time.Time, service, messageType string) {

--- a/fleetspeak/src/server/stats.go
+++ b/fleetspeak/src/server/stats.go
@@ -41,7 +41,7 @@ func (s noopStatsCollector) MessageSaved(forClient bool, m *fspb.Message) {
 func (s noopStatsCollector) MessageProcessed(start, end time.Time, m *fspb.Message) {
 }
 
-func (s noopStatsCollector) MessageErrored(start, end time.Time, service string, isTemp bool, m *fspb.Message) {
+func (s noopStatsCollector) MessageErrored(start, end time.Time, isTemp bool, m *fspb.Message) {
 }
 
 func (s noopStatsCollector) MessageDropped(m *fspb.Message) {

--- a/fleetspeak/src/server/stats.go
+++ b/fleetspeak/src/server/stats.go
@@ -38,7 +38,7 @@ func (s noopStatsCollector) MessageIngested(backlogged bool, m *fspb.Message) {
 func (s noopStatsCollector) MessageSaved(forClient bool, m *fspb.Message) {
 }
 
-func (s noopStatsCollector) MessageProcessed(start, end time.Time, service, messageType string) {
+func (s noopStatsCollector) MessageProcessed(start, end time.Time, service string, m *fspb.Message) {
 }
 
 func (s noopStatsCollector) MessageErrored(start, end time.Time, service, messageType string, isTemp bool) {

--- a/fleetspeak/src/server/stats/collector.go
+++ b/fleetspeak/src/server/stats/collector.go
@@ -100,7 +100,7 @@ type Collector interface {
 
 	// MessageErrored is called when a message processing returned an error
 	// (temporary, or permanent).
-	MessageErrored(start, end time.Time, service string, permanent bool, m *fspb.Message)
+	MessageErrored(start, end time.Time, permanent bool, m *fspb.Message)
 
 	// MessageDropped is called when a message has been dropped because too many
 	// messages for the services are being processed. Like a temporary error, the

--- a/fleetspeak/src/server/stats/collector.go
+++ b/fleetspeak/src/server/stats/collector.go
@@ -105,7 +105,7 @@ type Collector interface {
 	// MessageDropped is called when a message has been dropped because too many
 	// messages for the services are being processed. Like a temporary error, the
 	// message will be retried after some minutes.
-	MessageDropped(service, messageType string)
+	MessageDropped(service string, m *fspb.Message)
 
 	// ClientPoll is called every time a client polls the server.
 	ClientPoll(info PollInfo)

--- a/fleetspeak/src/server/stats/collector.go
+++ b/fleetspeak/src/server/stats/collector.go
@@ -91,6 +91,7 @@ type Collector interface {
 	MessageIngested(backlogged bool, m *fspb.Message)
 
 	// MessageSaved is called when a message is first saved to the database.
+	// m.Data will have been set to nil for fully processed messages.
 	MessageSaved(forClient bool, m *fspb.Message)
 
 	// MessageProcessed is called when a message is successfully processed by the

--- a/fleetspeak/src/server/stats/collector.go
+++ b/fleetspeak/src/server/stats/collector.go
@@ -91,7 +91,7 @@ type Collector interface {
 	MessageIngested(backlogged bool, m *fspb.Message)
 
 	// MessageSaved is called when a message is first saved to the database.
-	MessageSaved(service, messageType string, forClient bool, savedPayloadBytes int)
+	MessageSaved(forClient bool, m *fspb.Message)
 
 	// MessageProcessed is called when a message is successfully processed by the
 	// server.

--- a/fleetspeak/src/server/stats/collector.go
+++ b/fleetspeak/src/server/stats/collector.go
@@ -96,7 +96,7 @@ type Collector interface {
 
 	// MessageProcessed is called when a message is successfully processed by the
 	// server.
-	MessageProcessed(start, end time.Time, service string, m *fspb.Message)
+	MessageProcessed(start, end time.Time, m *fspb.Message)
 
 	// MessageErrored is called when a message processing returned an error
 	// (temporary, or permanent).

--- a/fleetspeak/src/server/stats/collector.go
+++ b/fleetspeak/src/server/stats/collector.go
@@ -96,7 +96,7 @@ type Collector interface {
 
 	// MessageProcessed is called when a message is successfully processed by the
 	// server.
-	MessageProcessed(start, end time.Time, service, messageType string)
+	MessageProcessed(start, end time.Time, service string, m *fspb.Message)
 
 	// MessageErrored is called when a message processing returned an error
 	// (temporary, or permanent).

--- a/fleetspeak/src/server/stats/collector.go
+++ b/fleetspeak/src/server/stats/collector.go
@@ -105,7 +105,7 @@ type Collector interface {
 	// MessageDropped is called when a message has been dropped because too many
 	// messages for the services are being processed. Like a temporary error, the
 	// message will be retried after some minutes.
-	MessageDropped(service string, m *fspb.Message)
+	MessageDropped(m *fspb.Message)
 
 	// ClientPoll is called every time a client polls the server.
 	ClientPoll(info PollInfo)

--- a/fleetspeak/src/server/stats/collector.go
+++ b/fleetspeak/src/server/stats/collector.go
@@ -100,7 +100,7 @@ type Collector interface {
 
 	// MessageErrored is called when a message processing returned an error
 	// (temporary, or permanent).
-	MessageErrored(start, end time.Time, service, messageType string, permanent bool)
+	MessageErrored(start, end time.Time, service string, permanent bool, m *fspb.Message)
 
 	// MessageDropped is called when a message has been dropped because too many
 	// messages for the services are being processed. Like a temporary error, the


### PR DESCRIPTION
As discussed in #260, we change some of the methods in the [Collector](https://github.com/google/fleetspeak/blob/0d4b45d28dd8f4291220935fa984f39a282ce61b/fleetspeak/src/server/stats/collector.go#L88) interface.
The main motivations are:
- Consistency; the method [MessageIngested](https://github.com/google/fleetspeak/blob/0d4b45d28dd8f4291220935fa984f39a282ce61b/fleetspeak/src/server/stats/collector.go#L91) was not consistent with [MessageSaved](https://github.com/google/fleetspeak/blob/0d4b45d28dd8f4291220935fa984f39a282ce61b/fleetspeak/src/server/stats/collector.go#L94) for instance, because in the former, the whole [Message struct](https://github.com/google/fleetspeak/blob/0d4b45d28dd8f4291220935fa984f39a282ce61b/fleetspeak/src/common/proto/fleetspeak/common.pb.go#L146) was passed to the method while in the latter, the struct [was deconstructed before the method was called](https://github.com/google/fleetspeak/blob/0d4b45d28dd8f4291220935fa984f39a282ce61b/fleetspeak/src/server/internal/services/manager.go#L278).
- Flexibility; as the whole Message struct is now passed to each Collector method, the struct can be further deconstructed to extract more data and record new relevant stats.