### PR TITLE
Fix tests package name

### DIFF
--- a/fleetspeak/src/e2etesting/run_end_to_end_tests.go
+++ b/fleetspeak/src/e2etesting/run_end_to_end_tests.go
@@ -26,7 +26,7 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("Failed to start components: %v", err)
 	}
-	err = endtoendtests.RunTest(msAddress, componentsInfo.ClientIDs)
+	err = tests.RunTest(msAddress, componentsInfo.ClientIDs)
 	if err != nil {
 		return fmt.Errorf("Failed to run tests: %v", err)
 	}

--- a/fleetspeak/src/e2etesting/tests/end_to_end_tests.go
+++ b/fleetspeak/src/e2etesting/tests/end_to_end_tests.go
@@ -1,4 +1,4 @@
-package endtoendtests
+package tests
 
 import (
 	"context"

--- a/terraform/test_runner/run_tests.go
+++ b/terraform/test_runner/run_tests.go
@@ -38,7 +38,7 @@ func run() error {
 		}
 	}
 
-	err = endtoendtests.RunTest(*masterServerAddress, clientIDs)
+	err = tests.RunTest(*masterServerAddress, clientIDs)
 	if err != nil {
 		return fmt.Errorf("test failed: %v", err)
 	}


### PR DESCRIPTION
Changed package name (endtoendtests -> tests), because it was different from the last element in the path.