### PR TITLE
Add load balancing to FS installation in Google Cloud

### DIFF
--- a/fleetspeak/src/e2etesting/setup/setup_components.go
+++ b/fleetspeak/src/e2etesting/setup/setup_components.go
@@ -280,7 +280,7 @@ func modifyFleetspeakClientConfig(configDir string, httpsListenAddress string, n
 // BuildConfigurations builds Fleetspeak configuration files for provided servers and
 // number of clients that are supposed to be started on different machines
 func BuildConfigurations(configDir string, serverHosts []string, serverFrontendAddress string, numClients int, mysqlCredentials MysqlCredentials) error {
-	err := buildBaseConfiguration(configDir, mysqlCredentials, append(serverHosts, serverFrontendAddress))
+	err := buildBaseConfiguration(configDir, mysqlCredentials, []string{serverFrontendAddress})
 	if err != nil {
 		return fmt.Errorf("Failed to build base configuration: %v", err)
 	}

--- a/fleetspeak/src/e2etesting/setup/setup_components.go
+++ b/fleetspeak/src/e2etesting/setup/setup_components.go
@@ -216,7 +216,7 @@ func buildBaseConfiguration(configDir string, mysqlCredentials MysqlCredentials,
 	return nil
 }
 
-func modifyFleetspeakServerConfig(configDir string, fsServerHost string, fsFrontendPort, fsHTTPSListenPort, fsAdminPort int, newServerConfigPath, newServerServicesConfigPath string) error {
+func modifyFleetspeakServerConfig(configDir string, fsServerHost string, fsFrontendPort, fsAdminPort int, HTTPSListenAddress, newServerConfigPath, newServerServicesConfigPath string) error {
 	// Update server addresses
 	serverBaseConfigurationPath := path.Join(configDir, "server.config")
 
@@ -229,7 +229,8 @@ func modifyFleetspeakServerConfig(configDir string, fsServerHost string, fsFront
 	if err != nil {
 		return fmt.Errorf("Failed to unmarshal server.config: %v", err)
 	}
-	serverConfig.HttpsConfig.ListenAddress = fmt.Sprintf("%v:%v", fsServerHost, fsHTTPSListenPort)
+	//serverConfig.HttpsConfig.ListenAddress = fmt.Sprintf("%v:%v", fsServerHost, fsHTTPSListenPort)
+	serverConfig.HttpsConfig.ListenAddress = HTTPSListenAddress
 	serverConfig.AdminConfig.ListenAddress = fmt.Sprintf("%v:%v", fsServerHost, fsAdminPort)
 	err = ioutil.WriteFile(newServerConfigPath, []byte(proto.MarshalTextString(&serverConfig)), 0644)
 
@@ -278,8 +279,8 @@ func modifyFleetspeakClientConfig(configDir string, httpsListenAddress string, n
 
 // BuildConfigurations builds Fleetspeak configuration files for provided servers and
 // number of clients that are supposed to be started on different machines
-func BuildConfigurations(configDir string, serverHosts []string, numClients int, mysqlCredentials MysqlCredentials) error {
-	err := buildBaseConfiguration(configDir, mysqlCredentials, serverHosts)
+func BuildConfigurations(configDir string, serverHosts []string, serverFrontendAddress string, numClients int, mysqlCredentials MysqlCredentials) error {
+	err := buildBaseConfiguration(configDir, mysqlCredentials, append(serverHosts, serverFrontendAddress))
 	if err != nil {
 		return fmt.Errorf("Failed to build base configuration: %v", err)
 	}
@@ -292,23 +293,18 @@ func BuildConfigurations(configDir string, serverHosts []string, numClients int,
 	for i := 0; i < len(serverHosts); i++ {
 		serverConfigPath := path.Join(configDir, fmt.Sprintf("server%v.config", i))
 		serverServicesConfigPath := path.Join(configDir, fmt.Sprintf("server%v.services.config", i))
-		err := modifyFleetspeakServerConfig(configDir, serverHosts[i], frontendPort, httpsListenPort, adminPort, serverConfigPath, serverServicesConfigPath)
+		err := modifyFleetspeakServerConfig(configDir, serverHosts[i], frontendPort, adminPort, fmt.Sprintf("%v:%v", serverFrontendAddress, httpsListenPort), serverConfigPath, serverServicesConfigPath)
 		if err != nil {
 			return fmt.Errorf("Failed to build FS server configurations: %v", err)
 		}
 	}
 
 	// Build client configs
-	for i := 0; i < numClients; i++ {
-		serverIdx := i % len(serverHosts)
-		linuxConfigPath := path.Join(configDir, fmt.Sprintf("linux_client%v.config", i))
-		stateFilePath := fmt.Sprintf("client%v.state", i)
-		err := modifyFleetspeakClientConfig(configDir, fmt.Sprintf("%v:%v", serverHosts[serverIdx], httpsListenPort), linuxConfigPath, stateFilePath, ".")
-		if err != nil {
-			return fmt.Errorf("Failed to build FS client configurations: %v", err)
-		}
+	linuxConfigPath := path.Join(configDir, "linux_client.config")
+	err = modifyFleetspeakClientConfig(configDir, fmt.Sprintf("%v:%v", serverFrontendAddress, httpsListenPort), linuxConfigPath, "client.state", ".")
+	if err != nil {
+		return fmt.Errorf("Failed to build FS client configurations: %v", err)
 	}
-
 	return nil
 }
 
@@ -326,7 +322,7 @@ func (cc *ComponentsInfo) start(configDir string, msAddress string, numServers, 
 		frontendPort := adminPort + 1
 		serverConfigPath := path.Join(configDir, fmt.Sprintf("server%v.config", i))
 		serverServicesConfigPath := path.Join(configDir, fmt.Sprintf("server%v.services.config", i))
-		err := modifyFleetspeakServerConfig(configDir, "localhost", frontendPort, httpsListenPort, adminPort, serverConfigPath, serverServicesConfigPath)
+		err := modifyFleetspeakServerConfig(configDir, "localhost", frontendPort, adminPort, fmt.Sprintf("localhost:%v", httpsListenPort), serverConfigPath, serverServicesConfigPath)
 		if err != nil {
 			return fmt.Errorf("Failed to build FS server configurations: %v", err)
 		}

--- a/fleetspeak/src/e2etesting/setup/setup_components.go
+++ b/fleetspeak/src/e2etesting/setup/setup_components.go
@@ -14,8 +14,8 @@ import (
 	cpb "github.com/google/fleetspeak/fleetspeak/src/config/proto/fleetspeak_config"
 	fcpb "github.com/google/fleetspeak/fleetspeak/src/server/components/proto/fleetspeak_components"
 	grpcServicePb "github.com/google/fleetspeak/fleetspeak/src/server/grpcservice/proto/fleetspeak_grpcservice"
-	servicesPb "github.com/google/fleetspeak/fleetspeak/src/server/proto/fleetspeak_server"
 	servicesGrpc "github.com/google/fleetspeak/fleetspeak/src/server/proto/fleetspeak_server"
+	servicesPb "github.com/google/fleetspeak/fleetspeak/src/server/proto/fleetspeak_server"
 	"google.golang.org/grpc"
 	"io"
 	"io/ioutil"
@@ -230,7 +230,6 @@ func modifyFleetspeakServerConfig(configDir string, fsServerHost string, fsFront
 	if err != nil {
 		return fmt.Errorf("Failed to unmarshal server.config: %v", err)
 	}
-	//serverConfig.HttpsConfig.ListenAddress = fmt.Sprintf("%v:%v", fsServerHost, fsHTTPSListenPort)
 	serverConfig.HttpsConfig.ListenAddress = HTTPSListenAddress
 	serverConfig.AdminConfig.ListenAddress = fmt.Sprintf("%v:%v", fsServerHost, fsAdminPort)
 	err = ioutil.WriteFile(newServerConfigPath, []byte(proto.MarshalTextString(&serverConfig)), 0644)

--- a/terraform/fleetspeak_configurator/build_configs.go
+++ b/terraform/fleetspeak_configurator/build_configs.go
@@ -13,6 +13,7 @@ var (
 	configDir     = flag.String("config_dir", "", "Directory to put config files")
 	numClients    = flag.Int("num_clients", 1, "Number of clients")
 	serversFile   = flag.String("servers_file", "", "File with server hosts")
+	serverFrontendAddress = flag.String("frontend_address", "", "Frontend address for clients to connect")
 	mysqlAddress  = flag.String("mysql_address", "", "MySQL server address")
 	mysqlDatabase = flag.String("mysql_database", "", "MySQL database name to use")
 	mysqlUsername = flag.String("mysql_username", "", "MySQL username to use")
@@ -26,7 +27,7 @@ func run() error {
 	}
 	serverHosts := strings.Fields(string(dat))
 
-	err = setup.BuildConfigurations(*configDir, serverHosts, *numClients,
+	err = setup.BuildConfigurations(*configDir, serverHosts, *serverFrontendAddress, *numClients,
 		setup.MysqlCredentials{
 			Host:     *mysqlAddress,
 			Password: *mysqlPassword,

--- a/terraform/fs_client_start.sh
+++ b/terraform/fs_client_start.sh
@@ -3,7 +3,7 @@
 set -e
 
 touch communicator.txt
-touch client${self_index}.state
+touch client.state
 mkdir services
 
 export PATH=/snap/bin:$PATH
@@ -34,10 +34,10 @@ cp_from_bucket ${storage_bucket_url}/frr_python/wheel frr_python/wheel
 pip3 install --target=frr_python frr_python/wheel/*
 cp_from_bucket ${storage_bucket_url}/bin/client ./client
 cp_from_bucket ${storage_bucket_url}/protos/frr.textproto textservices/frr.textproto
-cp_from_bucket ${storage_bucket_url}/client_configs/linux_client${self_index}.config linux_client${self_index}.config
+cp_from_bucket ${storage_bucket_url}/client_configs/linux_client.config linux_client.config
 touch client${self_index}.ready
 gsutil cp client${self_index}.ready ${storage_bucket_url}/started_components/
 
 chmod +x client
 
-./client -logtostderr -config "linux_client${self_index}.config"
+./client -logtostderr -config "linux_client.config"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -59,6 +59,17 @@ resource "google_compute_firewall" "allow-tcp" {
   target_tags   = ["allow-tcp"]
 }
 
+// TODO(Alexandr-TS): Add firewall rules denying all the IPs except the Load balancer (local.lb_frontend_ip) to connect to fleetspeak servers.
+
+/*
+  TODO(Alexandr-TS): Add firewall rule for health checks (https://cloud.google.com/load-balancing/docs/health-check-concepts#ip-ranges),
+  and add health check support to the fleetspeak server binary.
+  In external projects the health checks should be supported properly.
+  In internal GCP projects non-default firewall rules will be automatically removed,
+  but the traffic will be distributed to all backend VMs, although they will be considered unhealthy
+  (https://cloud.google.com/load-balancing/docs/health-check-concepts#importance_of_firewall_rules).
+*/
+
 resource "google_compute_health_check" "tcp-health-check" {
   name = "tcp-health-check"
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,310 +1,310 @@
 variable "project_name" {
-    type = string
+  type = string
 }
 
 variable "num_clients" {
-    type = number
-    default = 1
+  type    = number
+  default = 1
 }
 
 variable "num_servers" {
-    type = number
-    default = 1
+  type    = number
+  default = 1
 }
 
 variable "vm_image" {
-    type = string
-    default = "ubuntu-1804-bionic-v20200317"
+  type    = string
+  default = "ubuntu-1804-bionic-v20200317"
 }
 
 locals {
-    ip_address_ranges = "10.132.0.0/20"
-    ip_fs_server_prefix = "10.132.1"
-    ip_fs_client_prefix = "10.132.2"
-    fs_admin_host = format("%s.0", local.ip_fs_server_prefix)
-    main_vm_host = cidrhost(local.ip_address_ranges, 10)
-    master_server_host = cidrhost(local.ip_address_ranges, 11)
-    lb_frontend_ip = cidrhost(local.ip_address_ranges, 12)
+  ip_address_ranges   = "10.132.0.0/20"
+  ip_fs_server_prefix = "10.132.1"
+  ip_fs_client_prefix = "10.132.2"
+  fs_admin_host       = format("%s.0", local.ip_fs_server_prefix)
+  main_vm_host        = cidrhost(local.ip_address_ranges, 10)
+  master_server_host  = cidrhost(local.ip_address_ranges, 11)
+  lb_frontend_ip      = cidrhost(local.ip_address_ranges, 12)
 }
 
 provider "google" {
-    version = "3.5.0"
+  version = "3.5.0"
 
-    project = var.project_name
-    region = "europe-west1"
-    zone = "europe-west1-b"
+  project = var.project_name
+  region  = "europe-west1"
+  zone    = "europe-west1-b"
 }
 
 resource "google_compute_network" "vpc_network" {
-    name = "terraform-network"
-    auto_create_subnetworks = false
+  name                    = "terraform-network"
+  auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "vpc_subnetwork" {
-    name = "terraform-network"
-    ip_cidr_range = "10.132.0.0/20"
-    region = "europe-west1"
-    network = google_compute_network.vpc_network.id
+  name          = "terraform-network"
+  ip_cidr_range = "10.132.0.0/20"
+  region        = "europe-west1"
+  network       = google_compute_network.vpc_network.id
 }
 
 resource "google_compute_firewall" "allow-tcp" {
-    name = "allow-tcp"
-    network = google_compute_network.vpc_network.self_link
+  name    = "allow-tcp"
+  network = google_compute_network.vpc_network.self_link
 
-    allow {
-        protocol = "tcp"
-    }
+  allow {
+    protocol = "tcp"
+  }
 
-    source_ranges = [local.ip_address_ranges]
-    target_tags = ["allow-tcp"]
+  source_ranges = [local.ip_address_ranges]
+  target_tags   = ["allow-tcp"]
 }
 
 resource "google_compute_health_check" "tcp-health-check" {
-    name = "tcp-health-check"
+  name = "tcp-health-check"
 
-    timeout_sec = 1
-    check_interval_sec = 1
-    healthy_threshold = 1
-    unhealthy_threshold = 5
+  timeout_sec         = 1
+  check_interval_sec  = 1
+  healthy_threshold   = 1
+  unhealthy_threshold = 5
 
-    tcp_health_check {
-        port = "8080"
-    }
+  tcp_health_check {
+    port = "8080"
+  }
 }
 
 resource "google_compute_forwarding_rule" "load-balancer-forwarding-rule" {
-    name = "load-balancer-forwarding-rule"
-    ip_address = local.lb_frontend_ip
-    load_balancing_scheme = "INTERNAL"
-    backend_service = google_compute_region_backend_service.fs-backend.id
-    ports = ["6060"]
-    network = google_compute_network.vpc_network.name
-    subnetwork = google_compute_subnetwork.vpc_subnetwork.name
+  name                  = "load-balancer-forwarding-rule"
+  ip_address            = local.lb_frontend_ip
+  load_balancing_scheme = "INTERNAL"
+  backend_service       = google_compute_region_backend_service.fs-backend.id
+  ports                 = ["6060"]
+  network               = google_compute_network.vpc_network.name
+  subnetwork            = google_compute_subnetwork.vpc_subnetwork.name
 }
 
 resource "google_compute_region_backend_service" "fs-backend" {
-    name = "fs-backend"
-    region = "europe-west1"
-    backend {
-        group = google_compute_instance_group.fs-servers.id
-    }
-    health_checks = [google_compute_health_check.tcp-health-check.id]
+  name   = "fs-backend"
+  region = "europe-west1"
+  backend {
+    group = google_compute_instance_group.fs-servers.id
+  }
+  health_checks = [google_compute_health_check.tcp-health-check.id]
 }
 
 resource "random_id" "bucket_name_suffix" {
-    byte_length = 4
+  byte_length = 4
 }
 
 resource "google_storage_bucket" "common-files-store" {
-    name = "common-files-store-${random_id.bucket_name_suffix.hex}"
-    location = "EU"
-    force_destroy = true
-    bucket_policy_only = true
+  name               = "common-files-store-${random_id.bucket_name_suffix.hex}"
+  location           = "EU"
+  force_destroy      = true
+  bucket_policy_only = true
 }
 
 resource "google_compute_instance" "vm_instance" {
-    name = "terraform-instance"
-    machine_type = "n1-standard-1"
+  name         = "terraform-instance"
+  machine_type = "n1-standard-1"
 
-    tags = ["allow-tcp"]
+  tags = ["allow-tcp"]
 
-    boot_disk {
-        initialize_params {
-            image = var.vm_image
-        }
+  boot_disk {
+    initialize_params {
+      image = var.vm_image
     }
+  }
 
-    depends_on = [
-        google_compute_network.vpc_network,
-    ]
+  depends_on = [
+    google_compute_network.vpc_network,
+  ]
 
-    network_interface {
-        network = google_compute_network.vpc_network.self_link
-        subnetwork = google_compute_subnetwork.vpc_subnetwork.self_link
-        network_ip = local.main_vm_host
-        access_config {
-        }
+  network_interface {
+    network    = google_compute_network.vpc_network.self_link
+    subnetwork = google_compute_subnetwork.vpc_subnetwork.self_link
+    network_ip = local.main_vm_host
+    access_config {
     }
+  }
 
-    metadata_startup_script = templatefile(
-        "main_vm_start.sh",
-        {
-            mysql_instance_connection_name = google_sql_database_instance.fs-db.connection_name
-            storage_bucket_url = google_storage_bucket.common-files-store.url
-            admin_host = local.fs_admin_host
-            master_server_host = local.master_server_host
-            ip_fs_server_prefix = local.ip_fs_server_prefix
-            num_servers = var.num_servers
-            num_clients = var.num_clients
-            lb_frontend_ip = local.lb_frontend_ip
-        }
-    )
-
-    service_account {
-        scopes = ["cloud-platform"]
+  metadata_startup_script = templatefile(
+    "main_vm_start.sh",
+    {
+      mysql_instance_connection_name = google_sql_database_instance.fs-db.connection_name
+      storage_bucket_url             = google_storage_bucket.common-files-store.url
+      admin_host                     = local.fs_admin_host
+      master_server_host             = local.master_server_host
+      ip_fs_server_prefix            = local.ip_fs_server_prefix
+      num_servers                    = var.num_servers
+      num_clients                    = var.num_clients
+      lb_frontend_ip                 = local.lb_frontend_ip
     }
+  )
+
+  service_account {
+    scopes = ["cloud-platform"]
+  }
 }
 
 resource "google_compute_instance" "master_server_instance" {
-    name = "master-server-instance"
-    machine_type = "n1-standard-1"
+  name         = "master-server-instance"
+  machine_type = "n1-standard-1"
 
-    tags = ["allow-tcp"]
+  tags = ["allow-tcp"]
 
-    boot_disk {
-        initialize_params {
-            image = var.vm_image
-        }
+  boot_disk {
+    initialize_params {
+      image = var.vm_image
     }
+  }
 
-    depends_on = [
-        google_compute_network.vpc_network,
-    ]
+  depends_on = [
+    google_compute_network.vpc_network,
+  ]
 
-    network_interface {
-        network = google_compute_network.vpc_network.self_link
-        subnetwork = google_compute_subnetwork.vpc_subnetwork.self_link
-        network_ip = local.master_server_host
-        access_config {
-        }
+  network_interface {
+    network    = google_compute_network.vpc_network.self_link
+    subnetwork = google_compute_subnetwork.vpc_subnetwork.self_link
+    network_ip = local.master_server_host
+    access_config {
     }
+  }
 
-    metadata_startup_script = templatefile(
-        "master_server_start.sh",
-        {
-            storage_bucket_url = google_storage_bucket.common-files-store.url
-            admin_host = local.fs_admin_host
-            master_server_host = local.master_server_host
-        }
-    )
-
-    service_account {
-        scopes = ["cloud-platform"]
+  metadata_startup_script = templatefile(
+    "master_server_start.sh",
+    {
+      storage_bucket_url = google_storage_bucket.common-files-store.url
+      admin_host         = local.fs_admin_host
+      master_server_host = local.master_server_host
     }
+  )
+
+  service_account {
+    scopes = ["cloud-platform"]
+  }
 }
 
 resource "google_compute_instance_group" "fs-servers" {
-    name = "fs-servers"
-    instances = [ for instance in google_compute_instance.fs_server_instance: instance.self_link ]
-    zone = "europe-west1-b"
+  name      = "fs-servers"
+  instances = [for instance in google_compute_instance.fs_server_instance : instance.self_link]
+  zone      = "europe-west1-b"
 }
 
 resource "google_compute_instance" "fs_server_instance" {
-    count = var.num_servers
-    name = "fs-server-instance-${count.index}"
-    machine_type = "n1-standard-1"
+  count        = var.num_servers
+  name         = "fs-server-instance-${count.index}"
+  machine_type = "n1-standard-1"
 
-    tags = ["allow-tcp"]
+  tags = ["allow-tcp"]
 
-    boot_disk {
-        initialize_params {
-            image = var.vm_image
-        }
+  boot_disk {
+    initialize_params {
+      image = var.vm_image
     }
+  }
 
-    depends_on = [
-        google_compute_network.vpc_network,
-    ]
+  depends_on = [
+    google_compute_network.vpc_network,
+  ]
 
-    network_interface {
-        network = google_compute_network.vpc_network.self_link
-        subnetwork = google_compute_subnetwork.vpc_subnetwork.self_link
-        network_ip = format("%s.%s", local.ip_fs_server_prefix, count.index)
-        access_config {
-        }
+  network_interface {
+    network    = google_compute_network.vpc_network.self_link
+    subnetwork = google_compute_subnetwork.vpc_subnetwork.self_link
+    network_ip = format("%s.%s", local.ip_fs_server_prefix, count.index)
+    access_config {
     }
+  }
 
-    metadata_startup_script = templatefile(
-        "fs_server_start.sh",
-        {
-            mysql_instance_connection_name = google_sql_database_instance.fs-db.connection_name
-            storage_bucket_url = google_storage_bucket.common-files-store.url
-            master_server_host = local.master_server_host
-            self_host = format("%s.%s", local.ip_fs_server_prefix, count.index)
-            self_index = count.index
-        }
-    )
-
-    service_account {
-        scopes = ["cloud-platform"]
+  metadata_startup_script = templatefile(
+    "fs_server_start.sh",
+    {
+      mysql_instance_connection_name = google_sql_database_instance.fs-db.connection_name
+      storage_bucket_url             = google_storage_bucket.common-files-store.url
+      master_server_host             = local.master_server_host
+      self_host                      = format("%s.%s", local.ip_fs_server_prefix, count.index)
+      self_index                     = count.index
     }
+  )
+
+  service_account {
+    scopes = ["cloud-platform"]
+  }
 }
 
 resource "google_compute_instance" "fs_client_instance" {
-    count = var.num_clients
-    name = "fs-client-instance-${count.index}"
-    machine_type = "n1-standard-1"
+  count        = var.num_clients
+  name         = "fs-client-instance-${count.index}"
+  machine_type = "n1-standard-1"
 
-    tags = ["allow-tcp"]
+  tags = ["allow-tcp"]
 
-    boot_disk {
-        initialize_params {
-            image = var.vm_image
-        }
+  boot_disk {
+    initialize_params {
+      image = var.vm_image
     }
+  }
 
-    depends_on = [
-        google_compute_network.vpc_network,
-    ]
+  depends_on = [
+    google_compute_network.vpc_network,
+  ]
 
-    network_interface {
-        network = google_compute_network.vpc_network.self_link
-        subnetwork = google_compute_subnetwork.vpc_subnetwork.self_link
-        network_ip = format("%s.%s", local.ip_fs_client_prefix, count.index)
-        access_config {
-        }
+  network_interface {
+    network    = google_compute_network.vpc_network.self_link
+    subnetwork = google_compute_subnetwork.vpc_subnetwork.self_link
+    network_ip = format("%s.%s", local.ip_fs_client_prefix, count.index)
+    access_config {
     }
+  }
 
-    metadata_startup_script = templatefile(
-        "fs_client_start.sh",
-        {
-            storage_bucket_url = google_storage_bucket.common-files-store.url
-            self_index = count.index
-        }
-    )
-
-    service_account {
-        scopes = ["cloud-platform"]
+  metadata_startup_script = templatefile(
+    "fs_client_start.sh",
+    {
+      storage_bucket_url = google_storage_bucket.common-files-store.url
+      self_index         = count.index
     }
+  )
+
+  service_account {
+    scopes = ["cloud-platform"]
+  }
 }
 
 resource "random_id" "db_name_suffix" {
-    byte_length = 4
+  byte_length = 4
 }
 
 resource "google_sql_database_instance" "fs-db" {
-    name = "fs-db-instance-1-${random_id.db_name_suffix.hex}"
-    region = "europe-west1"
+  name   = "fs-db-instance-1-${random_id.db_name_suffix.hex}"
+  region = "europe-west1"
 
-    settings {
-        tier = "db-f1-micro"
+  settings {
+    tier = "db-f1-micro"
 
-        database_flags {
-            name = "max_allowed_packet"
-            value = "1073741824"
-        }
-
-        database_flags {
-            name = "log_output"
-            value = "FILE"
-        }
-
-        database_flags {
-            name = "slow_query_log"
-            value = "on"
-        }
+    database_flags {
+      name  = "max_allowed_packet"
+      value = "1073741824"
     }
+
+    database_flags {
+      name  = "log_output"
+      value = "FILE"
+    }
+
+    database_flags {
+      name  = "slow_query_log"
+      value = "on"
+    }
+  }
 }
 
 resource "google_sql_user" "users" {
-    name = "fsuser"
-    instance = google_sql_database_instance.fs-db.name
-    password = "fsuserPass1!"
+  name     = "fsuser"
+  instance = google_sql_database_instance.fs-db.name
+  password = "fsuserPass1!"
 }
 
 resource "google_sql_database" "fs-db" {
-    name = "fleetspeak_test"
-    instance = google_sql_database_instance.fs-db.name
-    charset = "utf8mb4"
-    collation = "utf8mb4_unicode_ci"
+  name      = "fleetspeak_test"
+  instance  = google_sql_database_instance.fs-db.name
+  charset   = "utf8mb4"
+  collation = "utf8mb4_unicode_ci"
 }

--- a/terraform/main_vm_start.sh
+++ b/terraform/main_vm_start.sh
@@ -45,7 +45,7 @@ export PATH=/snap/bin:$GOPATH/bin:$PATH
 /snap/bin/go get -v -t github.com/Alexandr-TS/fleetspeak/... ||:
 
 cd $HOME/go/src/github.com/Alexandr-TS/fleetspeak/
-git checkout prep_cloud
+git checkout cloud_lb
 
 ln -fs /usr/bin/python3 /usr/bin/python
 
@@ -67,7 +67,7 @@ mkdir terraform/tmp
 
 seq -f ${ip_fs_server_prefix}.%g 0 $((${num_servers}-1)) > server_hosts.txt;
 
-go run terraform/fleetspeak_configurator/build_configs.go --config_dir=terraform/tmp/ --num_clients=${num_clients} --servers_file=server_hosts.txt --mysql_address=127.0.0.1:3306 --mysql_database=fleetspeak_test --mysql_username=fsuser --mysql_password=fsuserPass1!
+go run terraform/fleetspeak_configurator/build_configs.go --config_dir=terraform/tmp/ --num_clients=${num_clients} --servers_file=server_hosts.txt --frontend_address=${lb_frontend_ip} --mysql_address=127.0.0.1:3306 --mysql_database=fleetspeak_test --mysql_username=fsuser --mysql_password=fsuserPass1!
 
 for i in $(seq 0 $((${num_servers}-1))); do
     gsutil cp terraform/tmp/server$${i}.config ${storage_bucket_url}/server_configs/server$${i}.config
@@ -83,10 +83,7 @@ fi
 sleep 30
 
 gsutil cp terraform/tmp/textservices/frr.textproto ${storage_bucket_url}/protos/frr.textproto
-
-for i in $(seq 0 $((${num_clients}-1))); do
-    gsutil cp terraform/tmp/linux_client$${i}.config ${storage_bucket_url}/client_configs/linux_client$${i}.config
-done
+gsutil cp terraform/tmp/linux_client.config ${storage_bucket_url}/client_configs/linux_client.config
 
 if retry '[ $(gsutil ls -r ${storage_bucket_url}/started_components/client*ready | wc -l) -eq ${num_clients} ]'; then
     log "All clients connected"

--- a/terraform/main_vm_start.sh
+++ b/terraform/main_vm_start.sh
@@ -45,7 +45,7 @@ export PATH=/snap/bin:$GOPATH/bin:$PATH
 /snap/bin/go get -v -t github.com/Alexandr-TS/fleetspeak/... ||:
 
 cd $HOME/go/src/github.com/Alexandr-TS/fleetspeak/
-git checkout cloud_lb
+git checkout cloud_lb_dev
 
 ln -fs /usr/bin/python3 /usr/bin/python
 

--- a/terraform/main_vm_start.sh
+++ b/terraform/main_vm_start.sh
@@ -42,10 +42,8 @@ snap install --classic --channel=1.14/stable go
 export GOPATH=$HOME/go
 export PATH=/snap/bin:$GOPATH/bin:$PATH
 
-/snap/bin/go get -v -t github.com/Alexandr-TS/fleetspeak/... ||:
-
-cd $HOME/go/src/github.com/Alexandr-TS/fleetspeak/
-git checkout cloud_lb_dev
+/snap/bin/go get -v -t github.com/google/fleetspeak/... ||:
+cd $HOME/go/src/github.com/google/fleetspeak/
 
 ln -fs /usr/bin/python3 /usr/bin/python
 


### PR DESCRIPTION
Added internal TCP Load Balancer. Its main components: unmanaged instance group for FS servers, backend service, health check and forwarding rule.
Now there is only 1 frontend address, all FS clients use the same config file, clients are no longer assigned to servers manually anymore - it happens automatically by load balancer.