### PR TITLE
Add Load balancer to local FS installation for e2e testing

### DIFF
--- a/fleetspeak/src/e2etesting/balancer/balancer.go
+++ b/fleetspeak/src/e2etesting/balancer/balancer.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"math/rand"
 	"net"
 	"os"
 	"strings"
-    "time"
-    "log"
+	"time"
 )
 
 var (
@@ -44,19 +44,19 @@ func run() error {
 		if err != nil {
 			return fmt.Errorf("Failed to accept connection: %v", err)
 		}
-        var serverAddr string
-        var serverConn net.Conn
-        for {
-		    serverAddr = serverHosts[rand.Int() % len(serverHosts)]
-		    serverConn, err = net.Dial("tcp", serverAddr)
-            if err != nil {
-                log.Printf("Failed to connect to server (%v): %v, retrying...\n", serverAddr, err)
-                time.Sleep(time.Second * 1)
-            } else {
-                break
-            }
-        }
-        log.Printf("Connection accepted, server: %v\n", serverAddr)
+		var serverAddr string
+		var serverConn net.Conn
+		for {
+			serverAddr = serverHosts[rand.Int()%len(serverHosts)]
+			serverConn, err = net.Dial("tcp", serverAddr)
+			if err != nil {
+				log.Printf("Failed to connect to server (%v): %v, retrying...\n", serverAddr, err)
+				time.Sleep(time.Second * 1)
+			} else {
+				break
+			}
+		}
+		log.Printf("Connection accepted, server: %v\n", serverAddr)
 		go copy(serverConn, lbConn)
 		go copy(lbConn, serverConn)
 	}

--- a/fleetspeak/src/e2etesting/balancer/balancer.go
+++ b/fleetspeak/src/e2etesting/balancer/balancer.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"net"
+	"os"
+	"strings"
+    "time"
+    "log"
+)
+
+var (
+	serversFile        = flag.String("servers_file", "", "File with server hosts")
+	serverFrontendAddr = flag.String("frontend_address", "", "Frontend address for clients to connect")
+)
+
+func copy(wc io.WriteCloser, r io.Reader) {
+	defer wc.Close()
+	io.Copy(wc, r)
+}
+
+func run() error {
+	dat, err := ioutil.ReadFile(*serversFile)
+	if err != nil {
+		return fmt.Errorf("Failed to read serversFile: %v", err)
+	}
+	serverHosts := strings.Fields(string(dat))
+	if len(serverHosts) == 0 {
+		return fmt.Errorf("No server hosts were provided")
+	}
+
+	ln, err := net.Listen("tcp", *serverFrontendAddr)
+	if err != nil {
+		return fmt.Errorf("Failed to bind: %v", err)
+	}
+	log.Printf("Load balancer started on %v\n", *serverFrontendAddr)
+
+	for {
+		lbConn, err := ln.Accept()
+		if err != nil {
+			return fmt.Errorf("Failed to accept connection: %v", err)
+		}
+        var serverAddr string
+        var serverConn net.Conn
+        for {
+		    serverAddr = serverHosts[rand.Int() % len(serverHosts)]
+		    serverConn, err = net.Dial("tcp", serverAddr)
+            if err != nil {
+                log.Printf("Failed to connect to server (%v): %v, retrying...\n", serverAddr, err)
+                time.Sleep(time.Second * 1)
+            } else {
+                break
+            }
+        }
+        log.Printf("Connection accepted, server: %v\n", serverAddr)
+		go copy(serverConn, lbConn)
+		go copy(lbConn, serverConn)
+	}
+}
+
+func main() {
+	flag.Parse()
+	err := run()
+	if err != nil {
+		fmt.Printf("Load balancer failed: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/fleetspeak/src/e2etesting/balancer/balancer.go
+++ b/fleetspeak/src/e2etesting/balancer/balancer.go
@@ -46,12 +46,17 @@ func run() error {
 		}
 		var serverAddr string
 		var serverConn net.Conn
+		retriesLeft := 10
 		for {
 			serverAddr = serverHosts[rand.Int()%len(serverHosts)]
 			serverConn, err = net.Dial("tcp", serverAddr)
 			if err != nil {
 				log.Printf("Failed to connect to server (%v): %v, retrying...\n", serverAddr, err)
-				time.Sleep(time.Second * 1)
+				retriesLeft--
+				if retriesLeft < 0 {
+					return fmt.Errorf("Maximum number of retries exceeded - no active servers were found")
+				}
+				time.Sleep(time.Second * 2)
 			} else {
 				break
 			}

--- a/fleetspeak/src/e2etesting/run_end_to_end_tests.go
+++ b/fleetspeak/src/e2etesting/run_end_to_end_tests.go
@@ -18,10 +18,11 @@ var (
 )
 
 func run() error {
+	frontendAddress := "localhost:6000"
 	msAddress := "localhost:6059"
 
 	var componentsInfo setup.ComponentsInfo
-	err := componentsInfo.ConfigureAndStart(setup.MysqlCredentials{Host: *mysqlAddress, Password: *mysqlPassword, Username: *mysqlUsername, Database: *mysqlDatabase}, msAddress, *numServers, *numClients)
+	err := componentsInfo.ConfigureAndStart(setup.MysqlCredentials{Host: *mysqlAddress, Password: *mysqlPassword, Username: *mysqlUsername, Database: *mysqlDatabase}, frontendAddress, msAddress, *numServers, *numClients)
 	defer componentsInfo.KillAll()
 	if err != nil {
 		return fmt.Errorf("Failed to start components: %v", err)

--- a/fleetspeak/src/e2etesting/setup/setup_components.go
+++ b/fleetspeak/src/e2etesting/setup/setup_components.go
@@ -14,8 +14,8 @@ import (
 	cpb "github.com/google/fleetspeak/fleetspeak/src/config/proto/fleetspeak_config"
 	fcpb "github.com/google/fleetspeak/fleetspeak/src/server/components/proto/fleetspeak_components"
 	grpcServicePb "github.com/google/fleetspeak/fleetspeak/src/server/grpcservice/proto/fleetspeak_grpcservice"
-	servicesPb "github.com/google/fleetspeak/fleetspeak/src/server/proto/fleetspeak_server"
 	servicesGrpc "github.com/google/fleetspeak/fleetspeak/src/server/proto/fleetspeak_server"
+	servicesPb "github.com/google/fleetspeak/fleetspeak/src/server/proto/fleetspeak_server"
 	"google.golang.org/grpc"
 	"io"
 	"io/ioutil"
@@ -34,7 +34,7 @@ type serverInfo struct {
 // ComponentsInfo contains IDs of connected clients and exec.Cmds for all components
 type ComponentsInfo struct {
 	masterServerCmd *exec.Cmd
-    balancerCmd     *exec.Cmd
+	balancerCmd     *exec.Cmd
 	servers         []serverInfo
 	clientCmds      []*exec.Cmd
 	ClientIDs       []string
@@ -170,7 +170,7 @@ func buildBaseConfiguration(configDir string, mysqlCredentials MysqlCredentials,
 	config.ComponentsConfig.AdminConfig = new(fcpb.AdminConfig)
 	config.ComponentsConfig.AdminConfig.ListenAddress = "localhost:6061"
 
-    config.PublicHostPort = append(config.PublicHostPort, frontendAddr)
+	config.PublicHostPort = append(config.PublicHostPort, frontendAddr)
 
 	config.ServerComponentConfigurationFile = path.Join(configDir, "server.config")
 	config.TrustedCertFile = path.Join(configDir, "trusted_cert.pem")
@@ -283,7 +283,7 @@ func modifyFleetspeakClientConfig(configDir string, httpsListenAddress string, n
 // BuildConfigurations builds Fleetspeak configuration files for provided servers and
 // number of clients that are supposed to be started on different machines
 func BuildConfigurations(configDir string, serverHosts []string, numClients int, mysqlCredentials MysqlCredentials) error {
-    err := buildBaseConfiguration(configDir, mysqlCredentials, "10.132.0.12:6060")
+	err := buildBaseConfiguration(configDir, mysqlCredentials, "10.132.0.12:6060")
 	if err != nil {
 		return fmt.Errorf("Failed to build base configuration: %v", err)
 	}
@@ -324,11 +324,11 @@ func (cc *ComponentsInfo) start(configDir string, frontendAddress, msAddress str
 	startCommand(cc.masterServerCmd)
 
 	// Start servers and their services
-    var serverHosts string
+	var serverHosts string
 	for i := 0; i < numServers; i++ {
 		adminPort := firstAdminPort + i*3
 		httpsListenPort := adminPort - 1
-        serverHosts += fmt.Sprintf("localhost:%v\n", httpsListenPort)
+		serverHosts += fmt.Sprintf("localhost:%v\n", httpsListenPort)
 		frontendPort := adminPort + 1
 		serverConfigPath := path.Join(configDir, fmt.Sprintf("server%v.config", i))
 		serverServicesConfigPath := path.Join(configDir, fmt.Sprintf("server%v.services.config", i))
@@ -349,14 +349,14 @@ func (cc *ComponentsInfo) start(configDir string, frontendAddress, msAddress str
 		startCommand(serviceCmd)
 	}
 
-    // Start Load balancer
-    serverHostsFile := path.Join(configDir, "server_hosts.txt")
-    err := ioutil.WriteFile(serverHostsFile, []byte(serverHosts), 0644)
-    if err != nil {
-        return fmt.Errorf("Failed to write serverHostsFile: %v", err)
-    }
-    cc.balancerCmd = exec.Command("fleetspeak/src/e2etesting/balancer/balancer", "--servers_file", serverHostsFile, "--frontend_address", frontendAddress)
-    startCommand(cc.balancerCmd)
+	// Start Load balancer
+	serverHostsFile := path.Join(configDir, "server_hosts.txt")
+	err := ioutil.WriteFile(serverHostsFile, []byte(serverHosts), 0644)
+	if err != nil {
+		return fmt.Errorf("Failed to write serverHostsFile: %v", err)
+	}
+	cc.balancerCmd = exec.Command("fleetspeak/src/e2etesting/balancer/balancer", "--servers_file", serverHostsFile, "--frontend_address", frontendAddress)
+	startCommand(cc.balancerCmd)
 
 	// Start clients
 	serversStartTime := time.Now()
@@ -387,7 +387,7 @@ func (cc *ComponentsInfo) ConfigureAndStart(mysqlCredentials MysqlCredentials, f
 		return fmt.Errorf("Failed to create temporary dir: %v", err)
 	}
 
-    err = buildBaseConfiguration(configDir, mysqlCredentials, frontendAddress)
+	err = buildBaseConfiguration(configDir, mysqlCredentials, frontendAddress)
 	if err != nil {
 		return fmt.Errorf("Failed to build base Fleetspeak configuration: %v", err)
 	}


### PR DESCRIPTION
Balancer binary was added. It accepts all connections from FS clients, chooses random FS server and forwards their messages to each other. Now clients are not assigned to servers manually, and all the clients use a common address to connect (balancer address).