### PR TITLE
Change fetchResourceUsageRecordsTest to not use fake timestamps & modify time range to half-open interval

### DIFF
--- a/fleetspeak/src/server/mysql/clientstore.go
+++ b/fleetspeak/src/server/mysql/clientstore.go
@@ -383,7 +383,7 @@ func (d *Datastore) FetchResourceUsageRecords(ctx context.Context, id common.Cli
 				"process_terminated, mean_user_cpu_rate, max_user_cpu_rate, mean_system_cpu_rate, "+
 				"max_system_cpu_rate, mean_resident_memory_mib, max_resident_memory_mib "+
 				"FROM client_resource_usage_records WHERE client_id=? "+
-				"AND server_timestamp > ? AND server_timestamp < ?",
+				"AND server_timestamp >= ? AND server_timestamp < ?",
 			id.Bytes(),
 			startTimeRange.UnixNano(),
 			endTimeRange.UnixNano())

--- a/fleetspeak/src/server/sqlite/clientstore.go
+++ b/fleetspeak/src/server/sqlite/clientstore.go
@@ -388,7 +388,7 @@ func (d *Datastore) FetchResourceUsageRecords(ctx context.Context, id common.Cli
 				"process_terminated, mean_user_cpu_rate, max_user_cpu_rate, mean_system_cpu_rate, "+
 				"max_system_cpu_rate, mean_resident_memory_mib, max_resident_memory_mib "+
 				"FROM client_resource_usage_records WHERE client_id=? "+
-				"AND server_timestamp > ? AND server_timestamp < ?",
+				"AND server_timestamp >= ? AND server_timestamp < ?",
 			id.String(),
 			startTimeRange.UnixNano(),
 			endTimeRange.UnixNano())


### PR DESCRIPTION
This PR presents the following few changes:
- Enhance #294 by making the time range arguments `startTimestamp` and `endTimestamp` of the datastore function `FetchResourceUsageRecords` be treated as a half open interval: `[startTimestamp, endTimestamp)` instead of an open interval as before.
- Test the half-open interval with nanosecond precision.
- Change `fetchResourceUsageRecordsTest` such that it does *not* depend on a fake server timestamp, but rather on timestamps relative to the time the test suite runs.