### PR TITLE
Don't call glog.Exit on Windows

### DIFF
--- a/fleetspeak/src/client/entry/entry_windows.go
+++ b/fleetspeak/src/client/entry/entry_windows.go
@@ -3,6 +3,7 @@
 package entry
 
 import (
+	"os"
 	"time"
 
 	log "github.com/golang/glog"
@@ -39,7 +40,8 @@ loop:
 	}
 	changes <- svc.Status{State: svc.StopPending}
 
-	log.Exit("Stopping the service.")
+	log.Info("Stopping the service.")
+	os.Exit(2)
 	return
 }
 


### PR DESCRIPTION
log.Exit logs the message at FATAL severity which means:

 - We find fatal errors in the logs, which engineers are prone to investigate,
   wasting a few minutes of their time.

 - Package gloc writes unconditionally to stderr at this severity, which does
   not work for a Windows service.