### PR TITLE
Don't quit process, return from svc Execute function

### DIFF
--- a/fleetspeak/src/client/client/client.go
+++ b/fleetspeak/src/client/client/client.go
@@ -23,7 +23,8 @@ import (
 var configFile = flag.String("config", "", "Client configuration file, required.")
 var profileDir = flag.String("profile-dir", "/tmp", "Profile directory.")
 
-func innerMain() {
+// innerMain runs the fleetspeak client until done is closed.
+func innerMain(done <-chan struct{}) {
 	flag.Parse()
 
 	b, err := ioutil.ReadFile(*configFile)
@@ -57,6 +58,10 @@ func innerMain() {
 			},
 			Communicator: com,
 		})
+	go func() {
+		<-done
+		cl.Stop()
+	}
 	if err != nil {
 		log.Exitf("Error starting client: %v", err)
 	}

--- a/fleetspeak/src/client/entry/entry_unix.go
+++ b/fleetspeak/src/client/entry/entry_unix.go
@@ -4,5 +4,5 @@ package entry
 
 // RunMain starts the application.
 func RunMain(innerMain func(), _ /* windowsServiceName */ string) {
-	innerMain()
+	innerMain(make(chan struct{}))
 }


### PR DESCRIPTION
Per https://godoc.org/golang.org/x/sys/windows/svc#Handler we are supposed to
return from the Execute function. It is suspected that not doing so leads to the
service manager reporting "The FleetspeakService service terminated
unexpectedly"

This implements a graceful shutdown, and triggers it in between sending the
StopPending message and returning from the Execute callback. No such trigger for
the graceful shutdown is implemented on Unix.
