### PR TITLE
Update dependencies to fix build in Debian testing

### DIFF
--- a/fleetspeak/server-pkg-tmpl/debian/control
+++ b/fleetspeak/server-pkg-tmpl/debian/control
@@ -1,6 +1,6 @@
 Source: fleetspeak-server
 Maintainer: GRR Dev <grr-dev@googlegroups.com>
-Build-Depends: debhelper (>= 9), dh-systemd (>= 1.5), devscripts
+Build-Depends: debhelper (>= 9), debhelper (>= 9.20160709) | dh-systemd (>= 1.5), devscripts
 Standards-Version: 3.8.3
 Homepage: https://github.com/google/fleetspeak
 


### PR DESCRIPTION
Debian removed dh-systemd now. It was transitional since debhelper 9.20160709 anyways (i.e. empty dependency-only package).