### PR TITLE
Depend on new debhelper which includes dh-systemd

### DIFF
--- a/fleetspeak/client-pkg-tmpl/debian/control
+++ b/fleetspeak/client-pkg-tmpl/debian/control
@@ -1,6 +1,6 @@
 Source: fleetspeak-client
 Maintainer: GRR Dev <grr-dev@googlegroups.com>
-Build-Depends: debhelper (>= 9), dh-systemd (>= 1.5), devscripts
+Build-Depends: debhelper (>= 9), debhelper (>= 9.20160709) | dh-systemd (>= 1.5), devscripts
 Standards-Version: 3.8.3
 Homepage: https://github.com/google/fleetspeak
 


### PR DESCRIPTION
Fall back to new-enough dh-systemd if that is not available.

This replicated PR#311 (server package template) for the client package template.