### PR TITLE
Stop enforcing socket ownership checks

### DIFF
--- a/fleetspeak/src/client/socketservice/checks/sock_checks_windows.go
+++ b/fleetspeak/src/client/socketservice/checks/sock_checks_windows.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	
+	log "github.com/golang/glog"
 
 	"github.com/hectane/go-acl/api"
 	"golang.org/x/sys/windows"
@@ -56,7 +58,7 @@ func CheckSocketFile(socketPath string) error {
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/aa446645.aspx
 
 	if err := checkOwnership(parent); err != nil {
-		return fmt.Errorf("unexpected ownership of socketPath's (%q) parent directory: %v", socketPath, err)
+		log.Errorf("Unexpected ownership of socketPath's (%q) parent directory: %v", socketPath, err)
 	}
 
 	fi, err := os.Lstat(socketPath)
@@ -70,7 +72,7 @@ func CheckSocketFile(socketPath string) error {
 	}
 
 	if err := checkOwnership(socketPath); err != nil {
-		return fmt.Errorf("unexpected ownership of socketPath (%q): %v", socketPath, err)
+		log.Errorf("Unexpected ownership of socketPath (%q): %v", socketPath, err)
 	}
 
 	bytePipeFSPath, err := ioutil.ReadFile(socketPath)


### PR DESCRIPTION
These checks are failing mysteriously on our Windows fleet: we get different strings
for SID values. The threat model that justifies them is not super clear so let's
just stop enforcing them until we have some way to fix the issue.

Related: 4ed15af, b182443