### PR TITLE
Explicitly pass inherited handles to child process.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,7 +212,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.15'
+          go-version: '^1.17'
       - uses: actions/checkout@v2
         with:
           path: ${{ env.GOPATH }}/src/github.com/google/fleetspeak

--- a/fleetspeak/src/client/daemonservice/command/command_windows.go
+++ b/fleetspeak/src/client/daemonservice/command/command_windows.go
@@ -40,6 +40,11 @@ func (cmd *Command) addInPipeFDImpl() (*os.File, int, error) {
 	syscall.SetHandleInformation(syscall.Handle(fd), syscall.HANDLE_FLAG_INHERIT, 1)
 	cmd.filesToClose = append(cmd.filesToClose, pr)
 
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.AdditionalInheritedHandles = append(cmd.SysProcAttr.AdditionalInheritedHandles, syscall.Handle(fd))
+
 	return pw, int(fd), nil
 }
 
@@ -52,6 +57,11 @@ func (cmd *Command) addOutPipeFDImpl() (*os.File, int, error) {
 	fd := pw.Fd()
 	syscall.SetHandleInformation(syscall.Handle(fd), syscall.HANDLE_FLAG_INHERIT, 1)
 	cmd.filesToClose = append(cmd.filesToClose, pw)
+
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.AdditionalInheritedHandles = append(cmd.SysProcAttr.AdditionalInheritedHandles, syscall.Handle(fd))
 
 	return pr, int(fd), nil
 }

--- a/fleetspeak/src/client/daemonservice/command/command_windows.go
+++ b/fleetspeak/src/client/daemonservice/command/command_windows.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"os"
 	"syscall"
+
+	intprocess "github.com/google/fleetspeak/fleetspeak/src/client/internal/process"
 )
 
 func (cmd *Command) softKill() error {
@@ -27,16 +29,7 @@ func (cmd *Command) softKill() error {
 }
 
 func (cmd *Command) kill() error {
-	// Using the original terminateProcess implementation from https://github.com/golang/go/commit/105c5b50e0098720b9e24aea5efa8e161c31db6d#
-	// Calling cmd.Cmd.Process.Kill() would trigger 'DuplicateHandle: The handle is invalid.'
-	pid := cmd.Cmd.Process.Pid
-	h, e := syscall.OpenProcess(syscall.PROCESS_TERMINATE, false, uint32(pid))
-	if e != nil {
-		return os.NewSyscallError("OpenProcess", e)
-	}
-	defer syscall.CloseHandle(h)
-	e = syscall.TerminateProcess(h, uint32(1))
-	return os.NewSyscallError("TerminateProcess", e)
+	return intprocess.KillProcess(cmd.Cmd.Process)
 }
 
 func (cmd *Command) addInPipeFDImpl() (*os.File, int, error) {

--- a/fleetspeak/src/client/daemonservice/execution/execution.go
+++ b/fleetspeak/src/client/daemonservice/execution/execution.go
@@ -34,6 +34,7 @@ import (
 	"github.com/google/fleetspeak/fleetspeak/src/client/channel"
 	"github.com/google/fleetspeak/fleetspeak/src/client/daemonservice/command"
 	"github.com/google/fleetspeak/fleetspeak/src/client/internal/monitoring"
+	intprocess "github.com/google/fleetspeak/fleetspeak/src/client/internal/process"
 	"github.com/google/fleetspeak/fleetspeak/src/client/service"
 
 	fcpb "github.com/google/fleetspeak/fleetspeak/src/client/channel/proto/fleetspeak_channel"
@@ -616,7 +617,7 @@ func (e *Execution) heartbeatMonitorRoutine(pid int) {
 				}
 
 				process := os.Process{Pid: pid}
-				if err := process.Kill(); err != nil {
+				if err := intprocess.KillProcess(&process); err != nil {
 					log.Errorf("Error while killing a process that doesn't heartbeat - %s (pid %d): %v", e.daemonServiceName, pid, err)
 					continue // Keep retrying.
 				}

--- a/fleetspeak/src/client/internal/monitoring/resource_usage_fetcher_test.go
+++ b/fleetspeak/src/client/internal/monitoring/resource_usage_fetcher_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+        intprocess "github.com/google/fleetspeak/fleetspeak/src/client/internal/process"
+
 	log "github.com/golang/glog"
 )
 
@@ -98,7 +100,7 @@ while time.time() - t0 < 60.:
 		t.Fatalf("Unexpected error from Run(): %v", err)
 	}
 	defer func() {
-		if err := cmd.Process.Kill(); err != nil {
+		if err := intprocess.KillProcess(cmd.Process); err != nil {
 			t.Errorf("Error killing cmd: %v", err)
 		}
 		if err := cmd.Wait(); err != nil {

--- a/fleetspeak/src/client/internal/monitoring/resource_usage_monitor.go
+++ b/fleetspeak/src/client/internal/monitoring/resource_usage_monitor.go
@@ -27,6 +27,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 
 	"github.com/google/fleetspeak/fleetspeak/src/client/service"
+        intprocess "github.com/google/fleetspeak/fleetspeak/src/client/internal/process"
 
 	tspb "github.com/golang/protobuf/ptypes/timestamp"
 	fspb "github.com/google/fleetspeak/fleetspeak/src/common/proto/fleetspeak"
@@ -383,8 +384,8 @@ func (m *ResourceUsageMonitor) enforceMemoryLimit(currResidentMemory int64) bool
 		log.Errorf("Failed to send kill notification to server: %v", err)
 	}
 
-	process := os.Process{Pid: m.pid}
-	if err := process.Kill(); err != nil {
+	process := &os.Process{Pid: m.pid}
+	if err := intprocess.KillProcess(process); err != nil {
 		log.Errorf("Error while killing a process that exceeded its memory limit (%d bytes) - %s pid %d: %v", m.memoryLimit, m.scope, m.pid, err)
 	}
 	return false

--- a/fleetspeak/src/client/internal/process/process.go
+++ b/fleetspeak/src/client/internal/process/process.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !windows
+
 package process
 
 import (

--- a/fleetspeak/src/client/internal/process/process.go
+++ b/fleetspeak/src/client/internal/process/process.go
@@ -1,0 +1,31 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package process
+
+import (
+	"os"
+)
+
+
+// Kill causes the Process to exit immediately. Kill does not wait until
+// the Process has actually exited. This only kills the Process itself,
+// not any other processes it may have started.
+//
+// TODO(https://github.com/google/fleetspeak/issues/341): remove as soon
+// as Go's own Process.Kill() works as expected.
+func KillProcess(p *os.Process) error {
+	return p.Kill()
+}
+

--- a/fleetspeak/src/client/internal/process/process_windows.go
+++ b/fleetspeak/src/client/internal/process/process_windows.go
@@ -1,0 +1,42 @@
+// Copyright 2021 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build windows
+
+package process
+
+import (
+	"os"
+	"syscall"
+)
+
+
+// Kill causes the Process to exit immediately. Kill does not wait until
+// the Process has actually exited. This only kills the Process itself,
+// not any other processes it may have started.
+//
+// TODO(https://github.com/google/fleetspeak/issues/341): remove as soon
+// as Go's own Process.Kill() works as expected.
+func KillProcess(p *os.Process) error {
+	// Using the original terminateProcess implementation from https://github.com/golang/go/commit/105c5b50e0098720b9e24aea5efa8e161c31db6d#
+	// Calling cmd.Cmd.Process.Kill() would trigger 'DuplicateHandle: The handle is invalid.'
+	h, e := syscall.OpenProcess(syscall.PROCESS_TERMINATE, false, uint32(p.Pid))
+	if e != nil {
+		return os.NewSyscallError("OpenProcess", e)
+	}
+	defer syscall.CloseHandle(h)
+	e = syscall.TerminateProcess(h, uint32(1))
+	return os.NewSyscallError("TerminateProcess", e)
+}
+

--- a/fleetspeak/src/client/socketservice/socketservice_test.go
+++ b/fleetspeak/src/client/socketservice/socketservice_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 
 	"github.com/google/fleetspeak/fleetspeak/src/client/clitesting"
+	intprocess "github.com/google/fleetspeak/fleetspeak/src/client/internal/process"
 	"github.com/google/fleetspeak/fleetspeak/src/comtesting"
 
 	sspb "github.com/google/fleetspeak/fleetspeak/src/client/socketservice/proto/fleetspeak_socketservice"
@@ -147,7 +148,7 @@ func TestLoopback(t *testing.T) {
 		t.Fatalf("cmd.Start() returned error: %v", err)
 	}
 	defer func() {
-		if err := cmd.Process.Kill(); err != nil {
+		if err := intprocess.KillProcess(cmd.Process); err != nil {
 			t.Errorf("failed to kill testclient[%d]: %v", cmd.Process.Pid, err)
 		}
 		if err := cmd.Wait(); err != nil {
@@ -177,7 +178,7 @@ func TestAckLoopback(t *testing.T) {
 		t.Fatalf("cmd.Start() returned error: %v", err)
 	}
 	defer func() {
-		if err := cmd.Process.Kill(); err != nil {
+		if err := intprocess.KillProcess(cmd.Process); err != nil {
 			t.Errorf("failed to kill testclient[%d]: %v", cmd.Process.Pid, err)
 		}
 		if err := cmd.Wait(); err != nil {
@@ -202,7 +203,7 @@ func TestStutteringLoopback(t *testing.T) {
 		t.Fatalf("cmd.Start() returned error: %v", err)
 	}
 	defer func() {
-		if err := cmd.Process.Kill(); err != nil {
+		if err := intprocess.KillProcess(cmd.Process); err != nil {
 			t.Errorf("failed to kill testclient[%d]: %v", cmd.Process.Pid, err)
 		}
 		if err := cmd.Wait(); err != nil {
@@ -293,7 +294,7 @@ func TestResourceMonitoring(t *testing.T) {
 		t.Fatalf("cmd.Start() returned error: %v", err)
 	}
 	defer func() {
-		if err := cmd.Process.Kill(); err != nil {
+		if err := intprocess.KillProcess(cmd.Process); err != nil {
 			t.Errorf("failed to kill testclient[%d]: %v", cmd.Process.Pid, err)
 		}
 		if err := cmd.Wait(); err != nil {

--- a/fleetspeak/src/client/stdinservice/stdinservice.go
+++ b/fleetspeak/src/client/stdinservice/stdinservice.go
@@ -27,6 +27,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 
 	"github.com/google/fleetspeak/fleetspeak/src/client/internal/monitoring"
+	intprocess "github.com/google/fleetspeak/fleetspeak/src/client/internal/process"
 	"github.com/google/fleetspeak/fleetspeak/src/client/service"
 
 	sspb "github.com/google/fleetspeak/fleetspeak/src/client/stdinservice/proto/fleetspeak_stdinservice"
@@ -113,7 +114,7 @@ func (s *StdinService) ProcessMessage(ctx context.Context, m *fspb.Message) erro
 		err = fmt.Errorf("context done: %v", ctx.Err())
 
 		// The error message string literal is a copypaste from exec_unix.go .
-		if e := cmd.Process.Kill(); e != nil && e.Error() != "os: process already finished" {
+		if e := intprocess.KillProcess(cmd.Process); e != nil && e.Error() != "os: process already finished" {
 			err = fmt.Errorf("%v; also, an error occurred while killing the process: %v", err, e)
 		}
 


### PR DESCRIPTION
Starting with Go 1.17, on Windows handles that are to be inherited by a child process have to be listed explicitly. See:
https://golang.org/doc/go1.17#syscall

The change in Go is effectively backwards-incompatible. Go 1.16 behavior was for child processes to inherit all inheritable handles.

Adjusting daemonservice Windows command launcher to use newly introduced attributes.