### PR TITLE
Improve server connector timeouts handling.

### DIFF
--- a/fleetspeak_python/fleetspeak/server_connector/connector.py
+++ b/fleetspeak_python/fleetspeak/server_connector/connector.py
@@ -80,7 +80,8 @@ def RetryLoop(func: Callable[[datetime.timedelta], _T],
         raise
       time.sleep(sleep.total_seconds())
       sleep *= 2
-      time_left = max(datetime.timedelta(0), deadline - datetime.datetime.now())
+      time_left = max(datetime.timedelta(0),
+                      deadline - datetime.datetime.now())
       cur_timeout = min(time_left, single_try_timeout)
 
 

--- a/fleetspeak_python/fleetspeak/server_connector/connector.py
+++ b/fleetspeak_python/fleetspeak/server_connector/connector.py
@@ -69,18 +69,18 @@ def RetryLoop(func: Callable[[datetime.timedelta], _T],
   timeout = timeout or DEFAULT_TIMEOUT
   single_try_timeout = single_try_timeout or timeout
 
-  deadline = time.time() + timeout.total_seconds()
+  deadline = datetime.datetime.now() + timeout
   cur_timeout = single_try_timeout
-  sleep = 1
+  sleep = datetime.timedelta(seconds=1)
   while True:
     try:
       return func(cur_timeout)
     except grpc.RpcError:
-      if time.time() + sleep > deadline:
+      if datetime.datetime.now() + sleep > deadline:
         raise
-      time.sleep(sleep)
+      time.sleep(sleep.total_seconds())
       sleep *= 2
-      time_left = datetime.timedelta(seconds=max(0, deadline - time.time()))
+      time_left = max(datetime.timedelta(0), deadline - datetime.datetime.now())
       cur_timeout = min(time_left, single_try_timeout)
 
 

--- a/fleetspeak_python/fleetspeak/server_connector/connector_test.py
+++ b/fleetspeak_python/fleetspeak/server_connector/connector_test.py
@@ -76,7 +76,8 @@ class RetryLoopTest(absltest.TestCase):
 
   @mock.patch.object(time, "sleep")
   @mock.patch.object(time, "time")
-  def testDefaultSingleTryTimeoutIsEqualToDefaultTimeout(self, time_mock, sleep_mock):
+  def testDefaultSingleTryTimeoutIsEqualToDefaultTimeout(
+      self, time_mock, sleep_mock):
     cur_time = [0]
 
     def SleepMock(v: float) -> None:
@@ -148,7 +149,9 @@ class ClientTest(absltest.TestCase):
 
   def testDeletePendingMessagesIsRetried(self):
     t = self._fakeStub()
-    t.DeletePendingMessages.side_effect = [grpc.RpcError("error"), mock.DEFAULT]
+    t.DeletePendingMessages.side_effect = [
+        grpc.RpcError("error"), mock.DEFAULT
+    ]
 
     s = connector.OutgoingConnection(None, 'test', t)
     s.DeletePendingMessages(admin_pb2.DeletePendingMessagesRequest())
@@ -180,7 +183,9 @@ class ClientTest(absltest.TestCase):
 
   def testGetPendingMessageCountIsRetried(self):
     t = self._fakeStub()
-    t.GetPendingMessageCount.side_effect = [grpc.RpcError("error"), mock.DEFAULT]
+    t.GetPendingMessageCount.side_effect = [
+        grpc.RpcError("error"), mock.DEFAULT
+    ]
 
     s = connector.OutgoingConnection(None, 'test', t)
     s.GetPendingMessageCount(admin_pb2.GetPendingMessageCountRequest())


### PR DESCRIPTION
This PR introduces a `single_try_timeout: Optional[float]` argument to all server connector methods. The goal is to have a finer-grained control about timeouts behavior. We want to support the cases when we'd have a larger total timeout and a smaller single try timeout - this way DEADLINE_EXCEEDED is encountered, the method call could be retried multiple times. This would be different from the current behavior: currently, if the method uses all of the "timeout" time and then fails (due to DEADLINE_EXCEEDED, for example), then the method call is not retried at all.

This PR also overhauls the server connector tests (they now use Python's mock library instead of ad-hoc fake objects).