### PR TITLE
Remove obsolete mentions of "plugins"

### DIFF
--- a/fleetspeak/build.sh
+++ b/fleetspeak/build.sh
@@ -63,16 +63,6 @@ function build_single_main_file {
   )
 }
 
-function build_single_plugin_file {
-  local readonly F=${1}
-  local readonly COMPILED="${F%.go}.so"
-
-  time (
-    /bin/echo >&2 "Building ${F} => ${COMPILED} "
-    go build -buildmode=plugin -o "${COMPILED}" "${F}"
-  )
-}
-
 time (
   for f in ${MAIN_FILES}; do
     build_single_main_file "${f}"

--- a/fleetspeak/build.sh
+++ b/fleetspeak/build.sh
@@ -34,7 +34,7 @@ cd "${SCRIPT_DIR}"
 readonly GOS=$(/usr/bin/find . -name '*.go')
 # ${GOS} should not be double-quoted; disable lint check
 # shellcheck disable=SC2086
-readonly MAIN_FILES=$(grep -rl 'func main' ${GOS} | grep -v '^./src/server/plugins/.*/')
+readonly MAIN_FILES=$(grep -rl 'func main' ${GOS})
 
 export TIMEFORMAT='real %lR user %lU system %lS'
 


### PR DESCRIPTION
Go plugins are largely unused and it's wise not to use them.