### PR TITLE
Use case name for temp dirs in server unit test

### DIFF
--- a/fleetspeak/src/comtesting/tempdir.go
+++ b/fleetspeak/src/comtesting/tempdir.go
@@ -36,15 +36,11 @@ func GetTempDir(testName string) (string, func()) {
 		return tempDir, cleanupTempDir
 	}
 
-	tempDir = os.Getenv("TEST_TMPDIR")
-
-	if tempDir == "" {
-		d, err := ioutil.TempDir("", testName+"_")
-		if err != nil {
-			panic(fmt.Sprintf("Unable to create temp directory: %v", err))
-		}
-		tempDir = d
+	tempDir, err := ioutil.TempDir(os.Getenv("TEST_TMPDIR"), testName+"_")
+	if err != nil {
+		panic(fmt.Sprintf("Unable to create temp directory: %v", err))
 	}
+
 	log.Infof("Created temp directory: %s", tempDir)
 	return tempDir, cleanupTempDir
 }

--- a/fleetspeak/src/server/servertests/admin_test.go
+++ b/fleetspeak/src/server/servertests/admin_test.go
@@ -42,7 +42,7 @@ import (
 func TestBroadcastsAPI(t *testing.T) {
 	ctx := context.Background()
 
-	ts := testserver.Make(t, "server", "AdminServer", nil)
+	ts := testserver.Make(t, "server", t.Name(), nil)
 	defer ts.S.Stop()
 
 	as := admin.NewServer(ts.DS, nil)
@@ -78,7 +78,7 @@ func TestBroadcastsAPI(t *testing.T) {
 func TestMessageStatusAPI(t *testing.T) {
 	ctx := context.Background()
 
-	ts := testserver.Make(t, "server", "AdminServer", nil)
+	ts := testserver.Make(t, "server", t.Name(), nil)
 	defer ts.S.Stop()
 
 	as := admin.NewServer(ts.DS, nil)
@@ -145,7 +145,7 @@ func (m *mockStreamClientIdsServer) Context() context.Context {
 func TestListClientsAPI(t *testing.T) {
 	ctx := context.Background()
 
-	ts := testserver.Make(t, "server", "AdminServer", nil)
+	ts := testserver.Make(t, "server", t.Name(), nil)
 	defer ts.S.Stop()
 
 	as := admin.NewServer(ts.DS, nil)
@@ -246,7 +246,7 @@ func TestInsertMessageAPI(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	ts := testserver.Make(t, "server", "AdminServer", nil)
+	ts := testserver.Make(t, "server", t.Name(), nil)
 	defer ts.S.Stop()
 
 	key, err := ts.AddClient()
@@ -288,7 +288,7 @@ func TestInsertMessageAPI_LargeMessages(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	server := testserver.Make(t, "server", "AdminServer", nil)
+	server := testserver.Make(t, "server", t.Name(), nil)
 	defer server.S.Stop()
 
 	key, err := server.AddClient()
@@ -334,7 +334,7 @@ func TestPendingMessages(t *testing.T) {
 
 	ctx := context.Background()
 
-	ts := testserver.Make(t, "server", "TestPendingMessages", nil)
+	ts := testserver.Make(t, "server", t.Name(), nil)
 	defer ts.S.Stop()
 
 	key, err := ts.AddClient()
@@ -529,7 +529,7 @@ func (m *mockStreamClientContactsServer) Context() context.Context {
 func TestClientContacts(t *testing.T) {
 	ctx := context.Background()
 
-	ts := testserver.Make(t, "server", "TestPendingMessages", nil)
+	ts := testserver.Make(t, "server", t.Name(), nil)
 	defer ts.S.Stop()
 
 	as := admin.NewServer(ts.DS, nil)


### PR DESCRIPTION
Having a separate temp directory for each test case help isolate them.