### PR TITLE
Fixing fleetspeak_connector tests.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         run: |
           pip install wheel pytest
-          pip install -e ./fleetspeak_python
+          pip install -e ./fleetspeak_python[test]
           pip install -e ./frr_python
       - name: Lint
         # We want to address all golint warnings, except for

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,14 +192,14 @@ jobs:
           python-version: '3.9'
       - name: Install dependencies
         run: |
-          pip install wheel
+          pip install wheel pytest
           go get -v -t ./...
       - uses: ankane/setup-mysql@v1
         with:
           database: ${{ env.MYSQL_TEST_E2E_DB }}
       - name: Build
         run: |
-          pip install -e ./fleetspeak_python
+          pip install -e ./fleetspeak_python[test]
           pip install -e ./frr_python
           fleetspeak/build.sh
       - name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Set up Python
         run: |
-          pip install wheel
+          pip install wheel pytest
           pip install -e ./fleetspeak_python
           pip install -e ./frr_python
       - name: Lint

--- a/fleetspeak/test.sh
+++ b/fleetspeak/test.sh
@@ -66,7 +66,9 @@ time (
   time go test -race --timeout 2.5m ${TEST_GO_DIRS} || RC=1
 
   pretty_echo 'Executing Python tests.'
+  pushd ../fleetspeak_python
   python -m unittest discover --pattern '*_test.py' || RC=2
+  popd
 
   pretty_echo 'Executing Bash tests.'
   for s in ${TEST_SHS}; do

--- a/fleetspeak/test.sh
+++ b/fleetspeak/test.sh
@@ -66,9 +66,7 @@ time (
   time go test -race --timeout 2.5m ${TEST_GO_DIRS} || RC=1
 
   pretty_echo 'Executing Python tests.'
-  pushd ../fleetspeak_python
-  python -m unittest discover --pattern '*_test.py' || RC=2
-  popd
+  pytest -v ../fleetspeak_python || RC=2
 
   pretty_echo 'Executing Bash tests.'
   for s in ${TEST_SHS}; do

--- a/fleetspeak_python/setup.py
+++ b/fleetspeak_python/setup.py
@@ -183,7 +183,7 @@ setup(
         "grpcio>=1.24.1",
     ],
     extras_require={
-        "test": ["grpc-testing==1.0.0"],
+        "test": ["grpcio-testing==1.54.2"],
     },    
     package_data={
     },

--- a/fleetspeak_python/setup.py
+++ b/fleetspeak_python/setup.py
@@ -182,6 +182,9 @@ setup(
         "absl-py>=0.8.0",
         "grpcio>=1.24.1",
     ],
+    extras_require={
+        "test": ["grpc-testing==1.0.0"],
+    },    
     package_data={
     },
     data_files=["VERSION"],


### PR DESCRIPTION
* Mocking datetime.datetime.now() instead of time.time() as the implementation has changed.
* Ensuring the tests during GitHub Actions.